### PR TITLE
Added an additional test for structured data

### DIFF
--- a/src/data/immutable_data.rs
+++ b/src/data/immutable_data.rs
@@ -117,6 +117,7 @@ mod test {
     use cbor::{ Encoder, Decoder};
     use rustc_serialize::{Decodable, Encodable};
     use Random;
+    use traits::routing_trait::RoutingTrait;
 
     #[test]
     fn creation() {
@@ -128,6 +129,7 @@ mod test {
         let chunk = ImmutableData::new(data);
         let actual_name = chunk.calculate_name().0.as_ref().to_hex();
         assert_eq!(&expected_name, &actual_name);
+        assert_eq!(&chunk.calculate_name(), &chunk.get_name());
     }
 
     #[test]

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -16,5 +16,5 @@
 // See the Licences for the specific language governing permissions and limitations relating to use
 // of the MaidSafe Software.
 
-mod routing_trait;
+pub mod routing_trait;
 pub use self::routing_trait::*;

--- a/src/traits/routing_trait.rs
+++ b/src/traits/routing_trait.rs
@@ -25,10 +25,10 @@
 use common::NameType;
 
 pub trait RoutingTrait {
-	fn get_name(&self)->NameType;
-	fn get_owner(&self)->Option<Vec<u8>> { Option::None }
-	fn refresh(&self)->bool { false } // is this an account transfer type
-	fn merge(&self)->bool { false } // how do we merge these
+    fn get_name(&self)->NameType;
+    fn get_owner(&self)->Option<Vec<u8>> { Option::None }
+    fn refresh(&self)->bool { false } // is this an account transfer type
+    fn merge(&self)->bool { false } // how do we merge these
 }
 #[test]
 fn dummy()  {


### PR DESCRIPTION
The `routing_trait` module was made `pub` due to [an issue](https://github.com/rust-lang/rust/issues/18241) that appears to be a bug. Unfortunately this means there are two names referring to the same object, even outside of this crate. I don't have a solution for both right now.
