### PR TITLE
Random trait test mod refactoring & Sendable trait integartion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ rustc-serialize = "*"
 cbor = "*"
 sodiumoxide = "*"
 rand = "*"
-routing = "0.1.1"
+[dependencies.routing]
+git = "https://github.com/dirvine/routing.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,4 @@ rustc-serialize = "*"
 cbor = "*"
 sodiumoxide = "*"
 rand = "*"
-[dependencies.routing]
-git = "https://github.com/dirvine/routing.git"
+routing = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,4 @@ rustc-serialize = "*"
 cbor = "*"
 sodiumoxide = "*"
 rand = "*"
-[dependencies.routing]
-git = "https://github.com/dirvine/routing.git"
+routing = "0.1.1"

--- a/src/data/immutable_data.rs
+++ b/src/data/immutable_data.rs
@@ -22,8 +22,6 @@ use routing::name_type::NameType;
 use routing::message_interface::MessageInterface;
 use sodiumoxide::crypto;
 use std::fmt;
-use rand;
-use Random;
 
 #[derive(Clone)]
 pub struct ImmutableData {
@@ -66,20 +64,6 @@ impl ImmutableData {
     }
 }
 
-#[allow(unused_variables)]
-impl Random for ImmutableData {
-    fn generate_random() -> ImmutableData {
-        use rand::Rng;
-        let size = 64;
-        let mut data = Vec::with_capacity(size);
-        let mut rng = rand::thread_rng();
-        for i in 0..size {
-            data.push(rng.gen());
-        }
-        ImmutableData::new(data)
-    }
-}
-
 impl Encodable for ImmutableData {
     fn encode<E: Encoder>(&self, e: &mut E)->Result<(), E::Error> {
         CborTagEncode::new(5483_001, &(&self.value)).encode(e)
@@ -101,6 +85,21 @@ mod test {
     use rustc_serialize::{Decodable, Encodable};
     use Random;
     use routing::message_interface::MessageInterface;
+    use rand;
+
+    #[allow(unused_variables)]
+    impl Random for ImmutableData {
+        fn generate_random() -> ImmutableData {
+            use rand::Rng;
+            let size = 64;
+            let mut data = Vec::with_capacity(size);
+            let mut rng = rand::thread_rng();
+            for i in 0..size {
+                data.push(rng.gen());
+            }
+            ImmutableData::new(data)
+        }
+    }
 
     #[test]
     fn creation() {

--- a/src/data/immutable_data.rs
+++ b/src/data/immutable_data.rs
@@ -23,6 +23,7 @@ use routing::message_interface::MessageInterface;
 use sodiumoxide::crypto;
 use std::fmt;
 
+/// ImmutableData
 #[derive(Clone)]
 pub struct ImmutableData {
     value: Vec<u8>,
@@ -47,6 +48,7 @@ impl fmt::Debug for ImmutableData {
 }
 
 impl ImmutableData {
+    /// New instance of ImmutableData can be created using the new()
     pub fn new(value: Vec<u8>) -> ImmutableData {
         ImmutableData {
             value: value,
@@ -54,11 +56,12 @@ impl ImmutableData {
     }
 
     // debug cannot call RoutingTrait due to current visibility
+    /// Calculates the name for the Data based on the SHA512 Hash of the Value
     fn calculate_name(&self) -> NameType {
         let digest = crypto::hash::sha512::hash(&self.value);
         NameType(digest.0)
     }
-
+    /// Returns the vaue
     pub fn get_value(&self) -> &Vec<u8> {
         &self.value
     }

--- a/src/data/structured_data.rs
+++ b/src/data/structured_data.rs
@@ -16,11 +16,6 @@
 // See the Licences for the specific language governing permissions and limitations relating to use
 // of the MaidSafe Software.
 
-extern crate rustc_serialize;
-extern crate sodiumoxide;
-extern crate cbor;
-extern crate rand;
-
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use routing::name_type::NameType;

--- a/src/data/structured_data.rs
+++ b/src/data/structured_data.rs
@@ -23,6 +23,7 @@ use routing::message_interface::MessageInterface;
 
 
 
+/// StructuredData
 #[derive(Clone, PartialEq, Debug)]
 pub struct StructuredData {
     name: NameType,
@@ -42,6 +43,7 @@ impl MessageInterface for StructuredData {
 }
 
 impl StructuredData {
+    /// An instance of the StructuredData can be created by invoking the new()
     pub fn new(name: NameType, owner: NameType) -> StructuredData {
         StructuredData {
             name: name,
@@ -49,6 +51,7 @@ impl StructuredData {
             value: Vec::<Vec<NameType>>::new(),
         }
     }
+    /// Returns the value
     pub fn get_value(&self) -> &Vec<Vec<NameType>> {
         &self.value
     }

--- a/src/id/an_maid.rs
+++ b/src/id/an_maid.rs
@@ -17,11 +17,9 @@
 // of the MaidSafe Software.
 
 use cbor::CborTagEncode;
-use cbor;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
-use Random;
 use std::fmt;
 
 /// The following key types use the internal cbor tag to identify them and this
@@ -33,7 +31,7 @@ use std::fmt;
 /// ```
 /// extern crate sodiumoxide;
 /// extern crate maidsafe_types;
-/// // Generating publick and secret keys using sodiumoxide
+/// // Generating public and secret keys using sodiumoxide
 /// // Create AnMaid
 /// let an_maid : maidsafe_types::AnMaid = maidsafe_types::AnMaid::new();
 /// // Retrieving the values
@@ -62,6 +60,8 @@ impl fmt::Debug for AnMaid {
 }
 
 impl AnMaid {
+    /// An instance of AnMaid can be created by invoking the new()
+    /// Default contructed AnMaid instance is returned
     pub fn new() -> AnMaid {
         let (pub_sign_key, sec_sign_key) = crypto::sign::gen_keypair();
 
@@ -71,14 +71,16 @@ impl AnMaid {
         }
     }
 
+    /// Returns the PublicKey of the AnMaid
     pub fn get_public_key(&self) -> &crypto::sign::PublicKey {
         &self.public_key
     }
-
+    /// Returns the SecretKey of the AnMaid
     pub fn get_secret_key(&self) -> &crypto::sign::SecretKey {
         &self.secret_key
     }
 
+    /// Signs the data with the SecretKey of the AnMaid and recturns the Signed Data
     pub fn sign(&self, data : &[u8]) -> Vec<u8> {
         return crypto::sign::sign(&data, &self.secret_key)
     }

--- a/src/id/an_maid.rs
+++ b/src/id/an_maid.rs
@@ -35,7 +35,7 @@ use std::fmt;
 /// extern crate maidsafe_types;
 /// // Generating publick and secret keys using sodiumoxide
 /// // Create AnMaid
-/// let an_maid : maidsafe_types::AnMaid = maidsafe_types::Random::generate_random();
+/// let an_maid : maidsafe_types::AnMaid = maidsafe_types::AnMaid::new();
 /// // Retrieving the values
 /// let ref publicKeys = an_maid.get_public_key();
 /// ```
@@ -53,16 +53,6 @@ impl PartialEq for AnMaid {
     }
 }
 
-impl Random for AnMaid {
-    fn generate_random() -> AnMaid {
-        let (pub_sign_key, sec_sign_key) = crypto::sign::gen_keypair();
-
-        AnMaid {
-            public_key: pub_sign_key,
-            secret_key: sec_sign_key
-        }
-    }
-}
 
 impl fmt::Debug for AnMaid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -72,8 +62,21 @@ impl fmt::Debug for AnMaid {
 }
 
 impl AnMaid {
+    pub fn new() -> AnMaid {
+        let (pub_sign_key, sec_sign_key) = crypto::sign::gen_keypair();
+
+        AnMaid {
+            public_key: pub_sign_key,
+            secret_key: sec_sign_key
+        }
+    }
+
     pub fn get_public_key(&self) -> &crypto::sign::PublicKey {
         &self.public_key
+    }
+
+    pub fn get_secret_key(&self) -> &crypto::sign::SecretKey {
+        &self.secret_key
     }
 
     pub fn sign(&self, data : &[u8]) -> Vec<u8> {
@@ -112,6 +115,12 @@ mod test {
     use Random;
     use sodiumoxide::crypto;
     use super::AnMaid;
+
+    impl Random for AnMaid {
+        fn generate_random() -> AnMaid {
+            AnMaid::new()
+        }
+    }
 
     #[test]
     fn serialisation_an_maid() {

--- a/src/id/an_mpid.rs
+++ b/src/id/an_mpid.rs
@@ -20,9 +20,10 @@ use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
-use routing::name_type::NameType;
-use routing::message_interface::MessageInterface;
+use routing::NameType;
+use routing::sendable::Sendable;
 use std::fmt;
+use cbor;
 
 /// AnMpid
 ///
@@ -36,7 +37,7 @@ use std::fmt;
 /// let (pub_sign_key, sec_sign_key) = sodiumoxide::crypto::sign::gen_keypair();
 /// let (pub_asym_key, sec_asym_key) = sodiumoxide::crypto::asymmetricbox::gen_keypair();
 /// // Create AnMpid
-/// let an_mpid = maidsafe_types::AnMpid::new((pub_sign_key, pub_asym_key), (sec_sign_key, sec_asym_key), routing::name_type::NameType([3u8; 64]));
+/// let an_mpid = maidsafe_types::AnMpid::new((pub_sign_key, pub_asym_key), (sec_sign_key, sec_asym_key), routing::NameType([3u8; 64]));
 /// // Retrieving the values
 /// let ref publicKeys = an_mpid.get_public_keys();
 /// let ref secret_keys = an_mpid.get_secret_keys();
@@ -45,13 +46,13 @@ use std::fmt;
 ///
 #[derive(Clone)]
 pub struct AnMpid {
-	public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
-	secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
-	name: NameType,
+    public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
+    secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
+    name: NameType,
 }
 
-impl MessageInterface for AnMpid {
-    fn get_name(&self) -> NameType {
+impl Sendable for AnMpid {
+    fn name(&self) -> NameType {
         let sign_arr = &(&self.public_keys.0).0;
         let asym_arr = &(&self.public_keys.1).0;
 
@@ -69,15 +70,25 @@ impl MessageInterface for AnMpid {
         NameType(digest.0)
     }
 
-    fn get_owner(&self) -> Option<Vec<u8>> {
-        Some(self.name.0.as_ref().to_vec())
+    fn type_tag(&self)->u64 {
+        103
+    }
+
+    fn serialised_contents(&self)->Vec<u8> {
+        let mut e = cbor::Encoder::from_memory();
+        e.encode(&[&self]).unwrap();
+        e.into_bytes()      
+    }
+
+    fn owner(&self) -> Option<NameType> {
+        Some(self.name.clone())
     }
 }
 
 impl fmt::Debug for AnMpid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "AnMpid {{ public_keys:({:?}, {:?}), secret_keys:({:?}, {:?}), name: {:?} }}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
-        	self.secret_keys.0 .0.to_vec(), self.secret_keys.1 .0.to_vec(), self.name)
+            self.secret_keys.0 .0.to_vec(), self.secret_keys.1 .0.to_vec(), self.name)
     }
 }
 
@@ -91,48 +102,48 @@ impl PartialEq for AnMpid {
 }
 
 impl AnMpid {
-	/// Invoked to create an instance of AnMpid
-	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
-						 secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
-						 name_type: NameType) -> AnMpid {
-		AnMpid {
-		public_keys: public_keys,
-		secret_keys: secret_keys,
-		name: name_type
-		}
-	}
-	/// Returns the PublicKeys
-	pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
-		&self.public_keys
-	}
-	/// Returns the SecretKeys
-	pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
-		&self.secret_keys
-	}
-	/// Returns the name
-	pub fn get_name(&self) -> &NameType {
-		&self.name
-	}
+    /// Invoked to create an instance of AnMpid
+    pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
+                         secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
+                         name_type: NameType) -> AnMpid {
+        AnMpid {
+        public_keys: public_keys,
+        secret_keys: secret_keys,
+        name: name_type
+        }
+    }
+    /// Returns the PublicKeys
+    pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
+        &self.public_keys
+    }
+    /// Returns the SecretKeys
+    pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
+        &self.secret_keys
+    }
+    /// Returns the name
+    pub fn get_name(&self) -> &NameType {
+        &self.name
+    }
 }
 
 impl Encodable for AnMpid {
     fn encode<E: Encoder>(&self, e: &mut E)->Result<(), E::Error> {
-	let (crypto::sign::PublicKey(pub_sign_vec), crypto::asymmetricbox::PublicKey(pub_asym_vec)) = self.public_keys;
-	let (crypto::sign::SecretKey(sec_sign_vec), crypto::asymmetricbox::SecretKey(sec_asym_vec)) = self.secret_keys;
+    let (crypto::sign::PublicKey(pub_sign_vec), crypto::asymmetricbox::PublicKey(pub_asym_vec)) = self.public_keys;
+    let (crypto::sign::SecretKey(sec_sign_vec), crypto::asymmetricbox::SecretKey(sec_asym_vec)) = self.secret_keys;
 
-	CborTagEncode::new(5483_001, &(
-	    pub_sign_vec.as_ref(),
-	    pub_asym_vec.as_ref(),
-	    sec_sign_vec.as_ref(),
-	    sec_asym_vec.as_ref(),
-	    &self.name)).encode(e)
+    CborTagEncode::new(5483_001, &(
+        pub_sign_vec.as_ref(),
+        pub_asym_vec.as_ref(),
+        sec_sign_vec.as_ref(),
+        sec_asym_vec.as_ref(),
+        &self.name)).encode(e)
     }
 }
 
 impl Decodable for AnMpid {
     fn decode<D: Decoder>(d: &mut D)-> Result<AnMpid, D::Error> {
-	try!(d.read_u64());
-	let (pub_sign_vec, pub_asym_vec, sec_sign_vec, sec_asym_vec, name) : (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, NameType) = try!(Decodable::decode(d));
+    try!(d.read_u64());
+    let (pub_sign_vec, pub_asym_vec, sec_sign_vec, sec_asym_vec, name) : (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, NameType) = try!(Decodable::decode(d));
 
         let pub_sign_arr = convert_to_array!(pub_sign_vec, crypto::sign::PUBLICKEYBYTES);
         let pub_asym_arr = convert_to_array!(pub_asym_vec, crypto::asymmetricbox::PUBLICKEYBYTES);
@@ -143,53 +154,53 @@ impl Decodable for AnMpid {
             return Err(d.error("Bad AnMpid size"));
         }
 
-	let pub_keys = (crypto::sign::PublicKey(pub_sign_arr.unwrap()),
-			crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
-	let sec_keys = (crypto::sign::SecretKey(sec_sign_arr.unwrap()),
-			crypto::asymmetricbox::SecretKey(sec_asym_arr.unwrap()));
-	Ok(AnMpid::new(pub_keys, sec_keys, name))
+    let pub_keys = (crypto::sign::PublicKey(pub_sign_arr.unwrap()),
+            crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
+    let sec_keys = (crypto::sign::SecretKey(sec_sign_arr.unwrap()),
+            crypto::asymmetricbox::SecretKey(sec_asym_arr.unwrap()));
+    Ok(AnMpid::new(pub_keys, sec_keys, name))
     }
 }
 
 #[cfg(test)]
 mod test {
-	use super::*;
-	use cbor::{ Encoder, Decoder };
-	use Random;
-	use sodiumoxide::crypto;
-	use routing::name_type::NameType;	
+    use super::*;
+    use cbor::{ Encoder, Decoder };
+    use Random;
+    use sodiumoxide::crypto;
+    use routing;
 
-	impl Random for AnMpid {
-		fn generate_random() -> AnMpid {
-	        let (sign_pub_key, sign_sec_key) = crypto::sign::gen_keypair();
-	        let (asym_pub_key, asym_sec_key) = crypto::asymmetricbox::gen_keypair();
-			AnMpid {
-				public_keys: (sign_pub_key, asym_pub_key),
-				secret_keys: (sign_sec_key, asym_sec_key),
-				name: NameType::generate_random()
-			}
-		}
-	}
-
-#[test]
-	fn serialisation_an_mpid() {
-		let obj_before = AnMpid::generate_random();
-		let mut e = Encoder::from_memory();
-		e.encode(&[&obj_before]).unwrap();
-
-		let mut d = Decoder::from_bytes(e.as_bytes());
-		let obj_after: AnMpid = d.decode().next().unwrap().unwrap();
-
-		assert_eq!(obj_before, obj_after);
-	}
+    impl Random for AnMpid {
+        fn generate_random() -> AnMpid {
+            let (sign_pub_key, sign_sec_key) = crypto::sign::gen_keypair();
+            let (asym_pub_key, asym_sec_key) = crypto::asymmetricbox::gen_keypair();
+            AnMpid {
+                public_keys: (sign_pub_key, asym_pub_key),
+                secret_keys: (sign_sec_key, asym_sec_key),
+                name: routing::test_utils::Random::generate_random()
+            }
+        }
+    }
 
 #[test]
-	fn equality_assertion_an_mpid() {
-		let an_mpid_first = AnMpid::generate_random();
-		let an_mpid_second = an_mpid_first.clone();
-		let an_mpid_third = AnMpid::generate_random();
-		assert_eq!(an_mpid_first, an_mpid_second);
-		assert!(an_mpid_first != an_mpid_third);
-	}
-	
+    fn serialisation_an_mpid() {
+        let obj_before = AnMpid::generate_random();
+        let mut e = Encoder::from_memory();
+        e.encode(&[&obj_before]).unwrap();
+
+        let mut d = Decoder::from_bytes(e.as_bytes());
+        let obj_after: AnMpid = d.decode().next().unwrap().unwrap();
+
+        assert_eq!(obj_before, obj_after);
+    }
+
+#[test]
+    fn equality_assertion_an_mpid() {
+        let an_mpid_first = AnMpid::generate_random();
+        let an_mpid_second = an_mpid_first.clone();
+        let an_mpid_third = AnMpid::generate_random();
+        assert_eq!(an_mpid_first, an_mpid_second);
+        assert!(an_mpid_first != an_mpid_third);
+    }
+    
 }

--- a/src/id/an_mpid.rs
+++ b/src/id/an_mpid.rs
@@ -17,7 +17,6 @@
 // of the MaidSafe Software.
 
 use cbor::CborTagEncode;
-use cbor;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
@@ -92,6 +91,7 @@ impl PartialEq for AnMpid {
 }
 
 impl AnMpid {
+	/// Invoked to create an instance of AnMpid
 	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
 						 secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
 						 name_type: NameType) -> AnMpid {
@@ -101,12 +101,15 @@ impl AnMpid {
 		name: name_type
 		}
 	}
+	/// Returns the PublicKeys
 	pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
 		&self.public_keys
 	}
+	/// Returns the SecretKeys
 	pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
 		&self.secret_keys
 	}
+	/// Returns the name
 	pub fn get_name(&self) -> &NameType {
 		&self.name
 	}

--- a/src/id/an_mpid.rs
+++ b/src/id/an_mpid.rs
@@ -23,7 +23,6 @@ use sodiumoxide::crypto;
 use helper::*;
 use routing::name_type::NameType;
 use routing::message_interface::MessageInterface;
-use Random;
 use std::fmt;
 
 /// AnMpid
@@ -92,18 +91,6 @@ impl PartialEq for AnMpid {
     }
 }
 
-impl Random for AnMpid {
-	fn generate_random() -> AnMpid {
-        let (sign_pub_key, sign_sec_key) = crypto::sign::gen_keypair();
-        let (asym_pub_key, asym_sec_key) = crypto::asymmetricbox::gen_keypair();
-		AnMpid {
-			public_keys: (sign_pub_key, asym_pub_key),
-			secret_keys: (sign_sec_key, asym_sec_key),
-			name: NameType::generate_random()
-		}
-	}
-}
-
 impl AnMpid {
 	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
 						 secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
@@ -161,24 +148,45 @@ impl Decodable for AnMpid {
     }
 }
 
+#[cfg(test)]
+mod test {
+	use super::*;
+	use cbor::{ Encoder, Decoder };
+	use Random;
+	use sodiumoxide::crypto;
+	use routing::name_type::NameType;	
+
+	impl Random for AnMpid {
+		fn generate_random() -> AnMpid {
+	        let (sign_pub_key, sign_sec_key) = crypto::sign::gen_keypair();
+	        let (asym_pub_key, asym_sec_key) = crypto::asymmetricbox::gen_keypair();
+			AnMpid {
+				public_keys: (sign_pub_key, asym_pub_key),
+				secret_keys: (sign_sec_key, asym_sec_key),
+				name: NameType::generate_random()
+			}
+		}
+	}
 
 #[test]
-fn serialisation_an_mpid() {
-	let obj_before = AnMpid::generate_random();
-	let mut e = cbor::Encoder::from_memory();
-	e.encode(&[&obj_before]).unwrap();
+	fn serialisation_an_mpid() {
+		let obj_before = AnMpid::generate_random();
+		let mut e = Encoder::from_memory();
+		e.encode(&[&obj_before]).unwrap();
 
-	let mut d = cbor::Decoder::from_bytes(e.as_bytes());
-	let obj_after: AnMpid = d.decode().next().unwrap().unwrap();
+		let mut d = Decoder::from_bytes(e.as_bytes());
+		let obj_after: AnMpid = d.decode().next().unwrap().unwrap();
 
-	assert_eq!(obj_before, obj_after);
-}
+		assert_eq!(obj_before, obj_after);
+	}
 
 #[test]
-fn equality_assertion_an_mpid() {
-	let an_maid_first = AnMpid::generate_random();
-	let an_maid_second = an_maid_first.clone();
-	let an_maid_third = AnMpid::generate_random();
-	assert_eq!(an_maid_first, an_maid_second);
-	assert!(an_maid_first != an_maid_third);
+	fn equality_assertion_an_mpid() {
+		let an_mpid_first = AnMpid::generate_random();
+		let an_mpid_second = an_mpid_first.clone();
+		let an_mpid_third = AnMpid::generate_random();
+		assert_eq!(an_mpid_first, an_mpid_second);
+		assert!(an_mpid_first != an_mpid_third);
+	}
+	
 }

--- a/src/id/maid.rs
+++ b/src/id/maid.rs
@@ -17,7 +17,6 @@
 // of the MaidSafe Software.
 
 use cbor::CborTagEncode;
-use cbor;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
@@ -45,6 +44,8 @@ pub struct Maid {
 }
 
 impl Maid {
+    /// Invoked to create an instance of Maid
+    /// Symmetric public and secret keys of AnMaid and used to construct the Maid
     pub fn new(an_maid: &AnMaid) -> Maid {        
         let asym_keys = crypto::asymmetricbox::gen_keypair();
 
@@ -53,21 +54,21 @@ impl Maid {
             secret_keys: (an_maid.get_secret_key().clone(), asym_keys.1)
         }
     }
-
+    /// Returns the PublicKeys
     pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey){
         &self.public_keys
     }
-
+    /// Signs the data with the SecretKey and returns the Signed data
     pub fn sign(&self, data : &[u8]) -> Vec<u8> {
         return crypto::sign::sign(&data, &self.secret_keys.0)
     }
-
+    /// Encrypts and authenticates data. It returns a ciphertext and the Nonce.
     pub fn seal(&self, data : &[u8], to : &crypto::asymmetricbox::PublicKey) -> (Vec<u8>, crypto::asymmetricbox::Nonce) {
         let nonce = crypto::asymmetricbox::gen_nonce();
         let sealed = crypto::asymmetricbox::seal(data, &nonce, &to, &self.secret_keys.1);
         return (sealed, nonce);
     }
-
+    /// Verifies and decrypts the data
     pub fn open(
         &self,
         data : &[u8],

--- a/src/id/mod.rs
+++ b/src/id/mod.rs
@@ -16,12 +16,19 @@
 // See the Licences for the specific language governing permissions and limitations relating to use
 // of the MaidSafe Software.
 
+/// AnMaid
 pub mod an_maid;
+/// AnMpid
 pub mod an_mpid;
+/// Maid
 pub mod maid;
+/// Mpid
 pub mod mpid;
+/// PublicMaid
 pub mod public_maid;
+/// PublicMpid
 pub mod public_mpid;
+/// PublicAnMaid
 pub mod public_an_maid;
 
 pub use self::an_maid::*;

--- a/src/id/mpid.rs
+++ b/src/id/mpid.rs
@@ -24,7 +24,6 @@ use helper::*;
 use routing::name_type::NameType;
 use routing::message_interface::MessageInterface;
 use std::fmt;
-use Random;
 
 /// Mpid
 ///
@@ -75,17 +74,6 @@ impl fmt::Debug for Mpid {
     }
 }
 
-impl Random for Mpid {
-	fn generate_random() -> Mpid {
-        let (sign_pub_key, sign_sec_key) = crypto::sign::gen_keypair();
-        let (asym_pub_key, asym_sec_key) = crypto::asymmetricbox::gen_keypair();
-		Mpid {
-			public_keys: (sign_pub_key, asym_pub_key),
-			secret_keys: (sign_sec_key, asym_sec_key),
-			name: NameType::generate_random()
-		}
-	}
-}
 
 impl MessageInterface for Mpid {
     fn get_name(&self) -> NameType {
@@ -165,24 +153,46 @@ impl Decodable for Mpid {
     }
 }
 
+#[cfg(test)]
+mod test {
+	use super::*;
+	use cbor;
+	use sodiumoxide::crypto;
+	use routing::name_type::NameType;	
+	use Random;
+
+	impl Random for Mpid {
+		fn generate_random() -> Mpid {
+	        let (sign_pub_key, sign_sec_key) = crypto::sign::gen_keypair();
+	        let (asym_pub_key, asym_sec_key) = crypto::asymmetricbox::gen_keypair();
+			Mpid {
+				public_keys: (sign_pub_key, asym_pub_key),
+				secret_keys: (sign_sec_key, asym_sec_key),
+				name: NameType::generate_random()
+			}
+		}
+	}
+
 #[test]
-fn serialisation_mpid() {
-	let obj_before = Mpid::generate_random();
+	fn serialisation_mpid() {
+		let obj_before = Mpid::generate_random();
 
-	let mut e = cbor::Encoder::from_memory();
-	e.encode(&[&obj_before]).unwrap();
+		let mut e = cbor::Encoder::from_memory();
+		e.encode(&[&obj_before]).unwrap();
 
-	let mut d = cbor::Decoder::from_bytes(e.as_bytes());
-	let obj_after: Mpid = d.decode().next().unwrap().unwrap();
+		let mut d = cbor::Decoder::from_bytes(e.as_bytes());
+		let obj_after: Mpid = d.decode().next().unwrap().unwrap();
 
-	assert_eq!(obj_before, obj_after);
-}
+		assert_eq!(obj_before, obj_after);
+	}
 
 #[test]
-fn equality_assertion_mpid() {
-	let mpid_first = Mpid::generate_random();
-	let mpid_second = mpid_first.clone();
-	let mpid_third = Mpid::generate_random();
-	assert_eq!(mpid_first, mpid_second);
-	assert!(mpid_first != mpid_third);
+	fn equality_assertion_mpid() {
+		let mpid_first = Mpid::generate_random();
+		let mpid_second = mpid_first.clone();
+		let mpid_third = Mpid::generate_random();
+		assert_eq!(mpid_first, mpid_second);
+		assert!(mpid_first != mpid_third);
+	}
+	
 }

--- a/src/id/mpid.rs
+++ b/src/id/mpid.rs
@@ -17,7 +17,6 @@
 // of the MaidSafe Software.
 
 use cbor::CborTagEncode;
-use cbor;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
@@ -96,6 +95,7 @@ impl MessageInterface for Mpid {
 }
 
 impl Mpid {
+	/// A new instance of Mpid can be created by invoking the new()
 	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
 						 secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
 						 name_type: NameType) -> Mpid {
@@ -105,14 +105,15 @@ impl Mpid {
 		name: name_type
 		}
 	}
+	/// Returns the PublicKeys
 	pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey){
 		&self.public_keys
 	}
-
+	/// Returns the SecretKeys
 	pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
 		&self.secret_keys
 	}
-
+	/// Returns the name
 	pub fn get_name(&self) -> &NameType {
 		&self.name
 	}

--- a/src/id/mpid.rs
+++ b/src/id/mpid.rs
@@ -16,12 +16,13 @@
 // See the Licences for the specific language governing permissions and limitations relating to use
 // of the MaidSafe Software.
 
+use cbor;
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
-use routing::name_type::NameType;
-use routing::message_interface::MessageInterface;
+use routing::NameType;
+use routing::sendable::Sendable;
 use std::fmt;
 
 /// Mpid
@@ -39,7 +40,7 @@ use std::fmt;
 /// // Creating new Mpid
 /// let mpid  = maidsafe_types::id::mpid::Mpid::new((pub_sign_key, pub_asym_key),
 ///                     (sec_sign_key, sec_asym_key),
-///                     routing::name_type::NameType([6u8; 64]));
+///                     routing::NameType([6u8; 64]));
 ///
 /// // getting Mpid::public_keys
 /// let &(pub_sign, pub_asym) = mpid.get_public_keys();
@@ -48,13 +49,13 @@ use std::fmt;
 /// let &(sec_sign, sec_asym) = mpid.get_public_keys();
 ///
 /// // getting Mpid::name
-/// let name: &routing::name_type::NameType = mpid.get_name();
+/// let name: &routing::NameType = mpid.get_name();
 /// ```
 #[derive(Clone)]
 pub struct Mpid {
-	public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
-	secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
-	name: NameType
+    public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
+    secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
+    name: NameType
 }
 
 impl PartialEq for Mpid {
@@ -67,15 +68,15 @@ impl PartialEq for Mpid {
 }
 
 impl fmt::Debug for Mpid {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Mpid {{ public_keys:({:?}, {:?}), secret_keys:({:?}, {:?}), name: {:?} }}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
-        	self.secret_keys.0 .0.to_vec(), self.secret_keys.1 .0.to_vec(), self.name)
+            self.secret_keys.0 .0.to_vec(), self.secret_keys.1 .0.to_vec(), self.name)
     }
 }
 
 
-impl MessageInterface for Mpid {
-    fn get_name(&self) -> NameType {
+impl Sendable for Mpid {
+    fn name(&self) -> NameType {
         let sign_arr = &(&self.public_keys.0).0;
         let asym_arr = &(&self.public_keys.1).0;
 
@@ -92,45 +93,56 @@ impl MessageInterface for Mpid {
 
         NameType(digest.0)
     }
+
+    fn type_tag(&self)->u64 {
+        104
+    }
+
+    fn serialised_contents(&self)->Vec<u8> {
+        let mut e = cbor::Encoder::from_memory();
+        e.encode(&[&self]).unwrap();
+        e.into_bytes()      
+    }
+
 }
 
 impl Mpid {
-	/// A new instance of Mpid can be created by invoking the new()
-	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
-						 secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
-						 name_type: NameType) -> Mpid {
-		Mpid {
-		public_keys: public_keys,
-		secret_keys: secret_keys,
-		name: name_type
-		}
-	}
-	/// Returns the PublicKeys
-	pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey){
-		&self.public_keys
-	}
-	/// Returns the SecretKeys
-	pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
-		&self.secret_keys
-	}
-	/// Returns the name
-	pub fn get_name(&self) -> &NameType {
-		&self.name
-	}
+    /// A new instance of Mpid can be created by invoking the new()
+    pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
+                         secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
+                         name_type: NameType) -> Mpid {
+        Mpid {
+        public_keys: public_keys,
+        secret_keys: secret_keys,
+        name: name_type
+        }
+    }
+    /// Returns the PublicKeys
+    pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey){
+        &self.public_keys
+    }
+    /// Returns the SecretKeys
+    pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
+        &self.secret_keys
+    }
+    /// Returns the name
+    pub fn get_name(&self) -> &NameType {
+        &self.name
+    }
 }
 
 impl Encodable for Mpid {
     fn encode<E: Encoder>(&self, e: &mut E)->Result<(), E::Error> {
-	let (crypto::sign::PublicKey(pub_sign_vec), crypto::asymmetricbox::PublicKey(pub_asym_vec)) = self.public_keys;
-	let (crypto::sign::SecretKey(sec_sign_vec), crypto::asymmetricbox::SecretKey(sec_asym_vec)) = self.secret_keys;
+    let (crypto::sign::PublicKey(pub_sign_vec), crypto::asymmetricbox::PublicKey(pub_asym_vec)) = self.public_keys;
+    let (crypto::sign::SecretKey(sec_sign_vec), crypto::asymmetricbox::SecretKey(sec_asym_vec)) = self.secret_keys;
 
-	CborTagEncode::new(5483_001, &(
-	    pub_sign_vec.as_ref(),
-	    pub_asym_vec.as_ref(),
-	    sec_sign_vec.as_ref(),
-	    sec_asym_vec.as_ref(),
-	    &self.name)).encode(e)
-	}
+    CborTagEncode::new(5483_001, &(
+        pub_sign_vec.as_ref(),
+        pub_asym_vec.as_ref(),
+        sec_sign_vec.as_ref(),
+        sec_asym_vec.as_ref(),
+        &self.name)).encode(e)
+    }
 }
 
 impl Decodable for Mpid {
@@ -147,53 +159,53 @@ impl Decodable for Mpid {
         }
 
         let pub_keys = (crypto::sign::PublicKey(pub_sign_arr.unwrap()),
-		        crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
+                crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
         let sec_keys = (crypto::sign::SecretKey(sec_sign_arr.unwrap()),
-		        crypto::asymmetricbox::SecretKey(sec_asym_arr.unwrap()));
+                crypto::asymmetricbox::SecretKey(sec_asym_arr.unwrap()));
         Ok(Mpid::new(pub_keys, sec_keys, name))
     }
 }
 
 #[cfg(test)]
 mod test {
-	use super::*;
-	use cbor;
-	use sodiumoxide::crypto;
-	use routing::name_type::NameType;	
-	use Random;
+    use super::*;
+    use cbor;
+    use sodiumoxide::crypto;
+    use routing;    
+    use Random;
 
-	impl Random for Mpid {
-		fn generate_random() -> Mpid {
-	        let (sign_pub_key, sign_sec_key) = crypto::sign::gen_keypair();
-	        let (asym_pub_key, asym_sec_key) = crypto::asymmetricbox::gen_keypair();
-			Mpid {
-				public_keys: (sign_pub_key, asym_pub_key),
-				secret_keys: (sign_sec_key, asym_sec_key),
-				name: NameType::generate_random()
-			}
-		}
-	}
-
-#[test]
-	fn serialisation_mpid() {
-		let obj_before = Mpid::generate_random();
-
-		let mut e = cbor::Encoder::from_memory();
-		e.encode(&[&obj_before]).unwrap();
-
-		let mut d = cbor::Decoder::from_bytes(e.as_bytes());
-		let obj_after: Mpid = d.decode().next().unwrap().unwrap();
-
-		assert_eq!(obj_before, obj_after);
-	}
+    impl Random for Mpid {
+        fn generate_random() -> Mpid {
+            let (sign_pub_key, sign_sec_key) = crypto::sign::gen_keypair();
+            let (asym_pub_key, asym_sec_key) = crypto::asymmetricbox::gen_keypair();
+            Mpid {
+                public_keys: (sign_pub_key, asym_pub_key),
+                secret_keys: (sign_sec_key, asym_sec_key),
+                name: routing::test_utils::Random::generate_random()
+            }
+        }
+    }
 
 #[test]
-	fn equality_assertion_mpid() {
-		let mpid_first = Mpid::generate_random();
-		let mpid_second = mpid_first.clone();
-		let mpid_third = Mpid::generate_random();
-		assert_eq!(mpid_first, mpid_second);
-		assert!(mpid_first != mpid_third);
-	}
-	
+    fn serialisation_mpid() {
+        let obj_before = Mpid::generate_random();
+
+        let mut e = cbor::Encoder::from_memory();
+        e.encode(&[&obj_before]).unwrap();
+
+        let mut d = cbor::Decoder::from_bytes(e.as_bytes());
+        let obj_after: Mpid = d.decode().next().unwrap().unwrap();
+
+        assert_eq!(obj_before, obj_after);
+    }
+
+#[test]
+    fn equality_assertion_mpid() {
+        let mpid_first = Mpid::generate_random();
+        let mpid_second = mpid_first.clone();
+        let mpid_third = Mpid::generate_random();
+        assert_eq!(mpid_first, mpid_second);
+        assert!(mpid_first != mpid_third);
+    }
+    
 }

--- a/src/id/public_an_maid.rs
+++ b/src/id/public_an_maid.rs
@@ -23,9 +23,6 @@ use sodiumoxide::crypto;
 use helper::*;
 use routing::name_type::NameType;
 use routing::message_interface::MessageInterface;
-use Random;
-use rand;
-use std::mem;
 use std::fmt;
 
 /// PublicAnMaid
@@ -60,22 +57,6 @@ impl PartialEq for PublicAnMaid {
         let public1_equal = slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0);
         let signature = slice_equal(&self.signature.0, &other.signature.0);
         return public0_equal && public1_equal && signature && self.name == other.name;
-    }
-}
-
-impl Random for PublicAnMaid {
-    fn generate_random() -> PublicAnMaid {
-        let (pub_sign_key, _) = crypto::sign::gen_keypair();
-        let (pub_asym_key, _) = crypto::asymmetricbox::gen_keypair();
-        let mut arr: [u8; 64] = unsafe { mem::uninitialized() };
-        for i in 0..64 {
-            arr[i] = rand::random::<u8>();
-        }
-        PublicAnMaid {
-            public_keys: (pub_sign_key, pub_asym_key),
-            signature: crypto::sign::Signature(arr),
-            name: NameType::generate_random()
-        }
     }
 }
 
@@ -164,25 +145,52 @@ impl Decodable for PublicAnMaid {
     }
 }
 
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cbor;
+    use sodiumoxide::crypto;
+    use routing::name_type::NameType;   
+    use Random;
+    use rand;
+    use std::mem;
+
+    impl Random for PublicAnMaid {
+        fn generate_random() -> PublicAnMaid {
+            let (pub_sign_key, _) = crypto::sign::gen_keypair();
+            let (pub_asym_key, _) = crypto::asymmetricbox::gen_keypair();
+            let mut arr: [u8; 64] = unsafe { mem::uninitialized() };
+            for i in 0..64 {
+                arr[i] = rand::random::<u8>();
+            }
+            PublicAnMaid {
+                public_keys: (pub_sign_key, pub_asym_key),
+                signature: crypto::sign::Signature(arr),
+                name: NameType::generate_random()
+            }
+        }
+    }
 
 #[test]
-fn serialisation_public_anmaid() {
-    let obj_before = PublicAnMaid::generate_random();
-    let mut e = cbor::Encoder::from_memory();
-    e.encode(&[&obj_before]).unwrap();
+    fn serialisation_public_anmaid() {
+        let obj_before = PublicAnMaid::generate_random();
+        let mut e = cbor::Encoder::from_memory();
+        e.encode(&[&obj_before]).unwrap();
 
-    let mut d = cbor::Decoder::from_bytes(e.as_bytes());
-    let obj_after: PublicAnMaid = d.decode().next().unwrap().unwrap();
+        let mut d = cbor::Decoder::from_bytes(e.as_bytes());
+        let obj_after: PublicAnMaid = d.decode().next().unwrap().unwrap();
 
-    assert_eq!(obj_before, obj_after);
-}
+        assert_eq!(obj_before, obj_after);
+    }
 
 #[test]
-fn equality_assertion_public_anmaid() {
-    let first_obj = PublicAnMaid::generate_random();
-    let second_obj = PublicAnMaid::generate_random();
-    let cloned_obj = second_obj.clone();
+    fn equality_assertion_public_anmaid() {
+        let first_obj = PublicAnMaid::generate_random();
+        let second_obj = PublicAnMaid::generate_random();
+        let cloned_obj = second_obj.clone();
 
-    assert!(first_obj != second_obj);
-    assert!(second_obj == cloned_obj);
+        assert!(first_obj != second_obj);
+        assert!(second_obj == cloned_obj);
+    }
+    
 }

--- a/src/id/public_an_maid.rs
+++ b/src/id/public_an_maid.rs
@@ -16,12 +16,13 @@
 // See the Licences for the specific language governing permissions and limitations relating to use
 // of the MaidSafe Software.
 
+use cbor;
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
-use routing::name_type::NameType;
-use routing::message_interface::MessageInterface;
+use routing::NameType;
+use routing::sendable::Sendable;
 use std::fmt;
 
 /// PublicAnMaid
@@ -35,7 +36,7 @@ use std::fmt;
 /// let (pub_sign_key, _) = sodiumoxide::crypto::sign::gen_keypair();
 /// let (pub_asym_key, _) = sodiumoxide::crypto::asymmetricbox::gen_keypair();
 /// // Create PublicAnMaid
-/// let pub_an_maid = maidsafe_types::PublicAnMaid::new((pub_sign_key, pub_asym_key), sodiumoxide::crypto::sign::Signature([5u8; 64]), routing::name_type::NameType([99u8; 64]));
+/// let pub_an_maid = maidsafe_types::PublicAnMaid::new((pub_sign_key, pub_asym_key), sodiumoxide::crypto::sign::Signature([5u8; 64]), routing::NameType([99u8; 64]));
 /// // Retrieving the values
 /// let ref publicKeys = pub_an_maid.get_public_keys();
 /// let ref signature = pub_an_maid.get_signature();
@@ -68,8 +69,8 @@ impl fmt::Debug for PublicAnMaid {
     }
 }
 
-impl MessageInterface for PublicAnMaid {
-    fn get_name(&self) -> NameType {
+impl Sendable for PublicAnMaid {
+    fn name(&self) -> NameType {
         let sign_arr = &(&self.public_keys.0).0;
         let asym_arr = &(&self.public_keys.1).0;
 
@@ -87,8 +88,18 @@ impl MessageInterface for PublicAnMaid {
         NameType(digest.0)
     }
 
-    fn get_owner(&self) -> Option<Vec<u8>> {
-        Some(self.name.0.as_ref().to_vec())
+    fn type_tag(&self)->u64 {
+        105
+    }
+
+    fn serialised_contents(&self)->Vec<u8> {
+        let mut e = cbor::Encoder::from_memory();
+        e.encode(&[&self]).unwrap();
+        e.into_bytes()      
+    }
+
+    fn owner(&self) -> Option<NameType> {
+        Some(self.name.clone())
     }
 }
 
@@ -153,7 +164,7 @@ mod test {
     use super::*;
     use cbor;
     use sodiumoxide::crypto;
-    use routing::name_type::NameType;   
+    use routing;
     use Random;
     use rand;
     use std::mem;
@@ -169,7 +180,7 @@ mod test {
             PublicAnMaid {
                 public_keys: (pub_sign_key, pub_asym_key),
                 signature: crypto::sign::Signature(arr),
-                name: NameType::generate_random()
+                name: routing::test_utils::Random::generate_random()
             }
         }
     }

--- a/src/id/public_an_maid.rs
+++ b/src/id/public_an_maid.rs
@@ -17,7 +17,6 @@
 // of the MaidSafe Software.
 
 use cbor::CborTagEncode;
-use cbor;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
@@ -94,6 +93,7 @@ impl MessageInterface for PublicAnMaid {
 }
 
 impl PublicAnMaid {
+        /// new() is invoked to create an instance of the PublicAnMaid
         pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
                                                  signature: crypto::sign::Signature,
                                                  name: NameType) -> PublicAnMaid {
@@ -103,12 +103,15 @@ impl PublicAnMaid {
                 name: name
                 }
         }
+        /// Returns the PublicKeys
         pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
                 &self.public_keys
         }
+        /// Returns the Signature
         pub fn get_signature(&self) -> &crypto::sign::Signature {
                 &self.signature
         }
+        /// Return the name
         pub fn get_name(&self) -> &NameType {
                 &self.name
         }

--- a/src/id/public_maid.rs
+++ b/src/id/public_maid.rs
@@ -17,7 +17,6 @@
 // of the MaidSafe Software.
 
 use cbor::CborTagEncode;
-use cbor;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
@@ -112,6 +111,7 @@ impl fmt::Debug for PublicMaid {
 }
 
 impl PublicMaid {
+	/// An instanstance of the PublicMaid can be created using the new()
 	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
 						 maid_signature: crypto::sign::Signature,
 						 owner: NameType,
@@ -125,23 +125,23 @@ impl PublicMaid {
 		name: name,
 		}
 	}
-
+	/// Returns the PublicKeys
 	pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
 		&self.public_keys
 	}
-
+	/// Returns the Maid Signature
 	pub fn get_maid_signature(&self) -> &crypto::sign::Signature {
 		&self.maid_signature
 	}
-
+	/// Returns the Owner
 	pub fn get_owner(&self) -> &NameType {
 		&self.owner
 	}
-
+	/// Returns the Signature of PublicMaid
 	pub fn get_signature(&self) -> &crypto::sign::Signature {
 		&self.signature
 	}
-
+	/// Returns the Name
 	pub fn get_name(&self) -> &NameType {
 		&self.name
 	}

--- a/src/id/public_maid.rs
+++ b/src/id/public_maid.rs
@@ -24,9 +24,6 @@ use helper::*;
 use routing::name_type::NameType;
 use routing::message_interface::MessageInterface;
 use std::fmt;
-use Random;
-use std::mem;
-use rand;
 
 /// PublicMaid
 ///
@@ -114,27 +111,6 @@ impl fmt::Debug for PublicMaid {
     }
 }
 
-impl Random for PublicMaid {
-	fn generate_random() -> PublicMaid {
-        let (sign_pub_key, _) = crypto::sign::gen_keypair();
-        let (asym_pub_key, _) = crypto::asymmetricbox::gen_keypair();
-        let mut maid_signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
-        let mut signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
-        for i in 0..64 {
-            maid_signature_arr[i] = rand::random::<u8>();
-            signature_arr[i] = rand::random::<u8>();
-        }
-
-		PublicMaid {
-			public_keys: (sign_pub_key, asym_pub_key),
-			maid_signature: crypto::sign::Signature(maid_signature_arr),
-			owner: NameType::generate_random(),
-			signature: crypto::sign::Signature(signature_arr),
-			name: NameType::generate_random()
-		}
-	}
-}
-
 impl PublicMaid {
 	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
 						 maid_signature: crypto::sign::Signature,
@@ -209,24 +185,57 @@ impl Decodable for PublicMaid {
     }
 }
 
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cbor;
+    use sodiumoxide::crypto;
+    use routing::name_type::NameType;   
+    use Random;
+    use rand;
+    use std::mem;
+
+	impl Random for PublicMaid {
+		fn generate_random() -> PublicMaid {
+	        let (sign_pub_key, _) = crypto::sign::gen_keypair();
+	        let (asym_pub_key, _) = crypto::asymmetricbox::gen_keypair();
+	        let mut maid_signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
+	        let mut signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
+	        for i in 0..64 {
+	            maid_signature_arr[i] = rand::random::<u8>();
+	            signature_arr[i] = rand::random::<u8>();
+	        }
+
+			PublicMaid {
+				public_keys: (sign_pub_key, asym_pub_key),
+				maid_signature: crypto::sign::Signature(maid_signature_arr),
+				owner: NameType::generate_random(),
+				signature: crypto::sign::Signature(signature_arr),
+				name: NameType::generate_random()
+			}
+		}
+	}
+
 #[test]
-fn serialisation_public_maid() {
-	let obj_before = PublicMaid::generate_random();
+	fn serialisation_public_maid() {
+		let obj_before = PublicMaid::generate_random();
 
-	let mut e = cbor::Encoder::from_memory();
-	e.encode(&[&obj_before]).unwrap();
+		let mut e = cbor::Encoder::from_memory();
+		e.encode(&[&obj_before]).unwrap();
 
-	let mut d = cbor::Decoder::from_bytes(e.as_bytes());
-	let obj_after: PublicMaid = d.decode().next().unwrap().unwrap();
+		let mut d = cbor::Decoder::from_bytes(e.as_bytes());
+		let obj_after: PublicMaid = d.decode().next().unwrap().unwrap();
 
-	assert_eq!(obj_before, obj_after);
-}
+		assert_eq!(obj_before, obj_after);
+	}
 
 #[test]
-fn equality_assertion_public_maid() {
-	let public_maid_first = PublicMaid::generate_random();
-	let public_maid_second = public_maid_first.clone();
-	let public_maid_third = PublicMaid::generate_random();
-	assert_eq!(public_maid_first, public_maid_second);
-	assert!(public_maid_first != public_maid_third);
+	fn equality_assertion_public_maid() {
+		let public_maid_first = PublicMaid::generate_random();
+		let public_maid_second = public_maid_first.clone();
+		let public_maid_third = PublicMaid::generate_random();
+		assert_eq!(public_maid_first, public_maid_second);
+		assert!(public_maid_first != public_maid_third);
+	}
+	
 }

--- a/src/id/public_maid.rs
+++ b/src/id/public_maid.rs
@@ -16,12 +16,13 @@
 // See the Licences for the specific language governing permissions and limitations relating to use
 // of the MaidSafe Software.
 
+use cbor;
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
-use routing::name_type::NameType;
-use routing::message_interface::MessageInterface;
+use routing::NameType;
+use routing::sendable::Sendable;
 use std::fmt;
 
 /// PublicMaid
@@ -40,9 +41,9 @@ use std::fmt;
 /// // Creating new PublicMaid
 /// let public_maid  = maidsafe_types::PublicMaid::new((pub_sign_key, pub_asym_key),
 ///                     sodiumoxide::crypto::sign::Signature([2u8; 64]),
-///                     routing::name_type::NameType([8u8; 64]),
+///                     routing::NameType([8u8; 64]),
 ///                     sodiumoxide::crypto::sign::Signature([5u8; 64]),
-///                     routing::name_type::NameType([6u8; 64]));
+///                     routing::NameType([6u8; 64]));
 ///
 /// // getting PublicMaid::public_keys
 /// let &(pub_sign, pub_asym) = public_maid.get_public_keys();
@@ -51,26 +52,26 @@ use std::fmt;
 /// let maid_signature: &sodiumoxide::crypto::sign::Signature = public_maid.get_maid_signature();
 ///
 /// // getting PublicMaid::owner
-/// let owner: &routing::name_type::NameType = public_maid.get_owner();
+/// let owner: &routing::NameType = public_maid.get_owner();
 ///
 /// // getting PublicMaid::signature
 /// let signature: &sodiumoxide::crypto::sign::Signature = public_maid.get_signature();
 ///
 /// // getting PublicMaid::name
-/// let name: &routing::name_type::NameType = public_maid.get_name();
+/// let name: &routing::NameType = public_maid.get_name();
 /// ```
 
 #[derive(Clone)]
 pub struct PublicMaid {
-	public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
-	maid_signature: crypto::sign::Signature,
-	owner: NameType,
-	signature: crypto::sign::Signature,
-	name: NameType
+    public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
+    maid_signature: crypto::sign::Signature,
+    owner: NameType,
+    signature: crypto::sign::Signature,
+    name: NameType
 }
 
-impl MessageInterface for PublicMaid {
-    fn get_name(&self) -> NameType {
+impl Sendable for PublicMaid {
+    fn name(&self) -> NameType {
         let sign_arr = &(&self.public_keys.0).0;
         let asym_arr = &(&self.public_keys.1).0;
 
@@ -88,8 +89,18 @@ impl MessageInterface for PublicMaid {
         NameType(digest.0)
     }
 
-    fn get_owner(&self) -> Option<Vec<u8>> {
-        Some(self.owner.0.as_ref().to_vec())
+    fn type_tag(&self)->u64 {
+        106
+    }
+
+    fn serialised_contents(&self)->Vec<u8> {
+        let mut e = cbor::Encoder::from_memory();
+        e.encode(&[&self]).unwrap();
+        e.into_bytes()      
+    }
+
+    fn owner(&self) -> Option<NameType> {
+        Some(self.owner.clone())
     }
 }
 
@@ -104,68 +115,68 @@ impl PartialEq for PublicMaid {
 }
 
 impl fmt::Debug for PublicMaid {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "PublicMaid {{ public_keys:({:?}, {:?}), maid_signature:{:?}, owner:{:?}, signature:{:?}, name: {:?} }}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
-        	self.maid_signature.0.to_vec(), self.owner, self.signature.0.to_vec(), self.name)
+            self.maid_signature.0.to_vec(), self.owner, self.signature.0.to_vec(), self.name)
     }
 }
 
 impl PublicMaid {
-	/// An instanstance of the PublicMaid can be created using the new()
-	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
-						 maid_signature: crypto::sign::Signature,
-						 owner: NameType,
-						 signature: crypto::sign::Signature,
-						 name: NameType) -> PublicMaid {
-		PublicMaid {
-		public_keys: public_keys,
-		maid_signature: maid_signature,
-		owner: owner,
-		signature: signature,
-		name: name,
-		}
-	}
-	/// Returns the PublicKeys
-	pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
-		&self.public_keys
-	}
-	/// Returns the Maid Signature
-	pub fn get_maid_signature(&self) -> &crypto::sign::Signature {
-		&self.maid_signature
-	}
-	/// Returns the Owner
-	pub fn get_owner(&self) -> &NameType {
-		&self.owner
-	}
-	/// Returns the Signature of PublicMaid
-	pub fn get_signature(&self) -> &crypto::sign::Signature {
-		&self.signature
-	}
-	/// Returns the Name
-	pub fn get_name(&self) -> &NameType {
-		&self.name
-	}
+    /// An instanstance of the PublicMaid can be created using the new()
+    pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
+                         maid_signature: crypto::sign::Signature,
+                         owner: NameType,
+                         signature: crypto::sign::Signature,
+                         name: NameType) -> PublicMaid {
+        PublicMaid {
+        public_keys: public_keys,
+        maid_signature: maid_signature,
+        owner: owner,
+        signature: signature,
+        name: name,
+        }
+    }
+    /// Returns the PublicKeys
+    pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
+        &self.public_keys
+    }
+    /// Returns the Maid Signature
+    pub fn get_maid_signature(&self) -> &crypto::sign::Signature {
+        &self.maid_signature
+    }
+    /// Returns the Owner
+    pub fn get_owner(&self) -> &NameType {
+        &self.owner
+    }
+    /// Returns the Signature of PublicMaid
+    pub fn get_signature(&self) -> &crypto::sign::Signature {
+        &self.signature
+    }
+    /// Returns the Name
+    pub fn get_name(&self) -> &NameType {
+        &self.name
+    }
 }
 
 impl Encodable for PublicMaid {
-	fn encode<E: Encoder>(&self, e: &mut E)->Result<(), E::Error> {
-		let (crypto::sign::PublicKey(ref pub_sign_vec), crypto::asymmetricbox::PublicKey(pub_asym_vec)) = self.public_keys;
-		let crypto::sign::Signature(ref maid_signature) = self.maid_signature;
-		let crypto::sign::Signature(ref signature) = self.signature;
-		CborTagEncode::new(5483_001, &(
-			pub_sign_vec.as_ref(),
-			pub_asym_vec.as_ref(),
-			maid_signature.as_ref(),
-			&self.owner,
-			signature.as_ref(),
-			&self.name)).encode(e)
-	}
+    fn encode<E: Encoder>(&self, e: &mut E)->Result<(), E::Error> {
+        let (crypto::sign::PublicKey(ref pub_sign_vec), crypto::asymmetricbox::PublicKey(pub_asym_vec)) = self.public_keys;
+        let crypto::sign::Signature(ref maid_signature) = self.maid_signature;
+        let crypto::sign::Signature(ref signature) = self.signature;
+        CborTagEncode::new(5483_001, &(
+            pub_sign_vec.as_ref(),
+            pub_asym_vec.as_ref(),
+            maid_signature.as_ref(),
+            &self.owner,
+            signature.as_ref(),
+            &self.name)).encode(e)
+    }
 }
 
 impl Decodable for PublicMaid {
     fn decode<D: Decoder>(d: &mut D)-> Result<PublicMaid, D::Error> {
-	try!(d.read_u64());
-	let (pub_sign_vec, pub_asym_vec, maid_signature_vec, owner, signature_vec, name) : (Vec<u8>, Vec<u8>, Vec<u8>, NameType, Vec<u8>, NameType) = try!(Decodable::decode(d));
+    try!(d.read_u64());
+    let (pub_sign_vec, pub_asym_vec, maid_signature_vec, owner, signature_vec, name) : (Vec<u8>, Vec<u8>, Vec<u8>, NameType, Vec<u8>, NameType) = try!(Decodable::decode(d));
 
         let pub_sign_arr = convert_to_array!(pub_sign_vec, crypto::sign::PUBLICKEYBYTES);
         let pub_asym_arr = convert_to_array!(pub_asym_vec, crypto::asymmetricbox::PUBLICKEYBYTES);
@@ -176,12 +187,12 @@ impl Decodable for PublicMaid {
             return Err(d.error("Bad PublicMaid size"));
         }
 
-	let pub_keys = (crypto::sign::PublicKey(pub_sign_arr.unwrap()),
-			crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
-	let parsed_maid_signature = crypto::sign::Signature(maid_signature_arr.unwrap());
-	let parsed_signature = crypto::sign::Signature(signature_arr.unwrap());
+    let pub_keys = (crypto::sign::PublicKey(pub_sign_arr.unwrap()),
+            crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
+    let parsed_maid_signature = crypto::sign::Signature(maid_signature_arr.unwrap());
+    let parsed_signature = crypto::sign::Signature(signature_arr.unwrap());
 
-	Ok(PublicMaid::new(pub_keys, parsed_maid_signature, owner, parsed_signature, name))
+    Ok(PublicMaid::new(pub_keys, parsed_maid_signature, owner, parsed_signature, name))
     }
 }
 
@@ -190,52 +201,52 @@ mod test {
     use super::*;
     use cbor;
     use sodiumoxide::crypto;
-    use routing::name_type::NameType;   
+    use routing;
     use Random;
     use rand;
     use std::mem;
 
-	impl Random for PublicMaid {
-		fn generate_random() -> PublicMaid {
-	        let (sign_pub_key, _) = crypto::sign::gen_keypair();
-	        let (asym_pub_key, _) = crypto::asymmetricbox::gen_keypair();
-	        let mut maid_signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
-	        let mut signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
-	        for i in 0..64 {
-	            maid_signature_arr[i] = rand::random::<u8>();
-	            signature_arr[i] = rand::random::<u8>();
-	        }
+    impl Random for PublicMaid {
+        fn generate_random() -> PublicMaid {
+            let (sign_pub_key, _) = crypto::sign::gen_keypair();
+            let (asym_pub_key, _) = crypto::asymmetricbox::gen_keypair();
+            let mut maid_signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
+            let mut signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
+            for i in 0..64 {
+                maid_signature_arr[i] = rand::random::<u8>();
+                signature_arr[i] = rand::random::<u8>();
+            }
 
-			PublicMaid {
-				public_keys: (sign_pub_key, asym_pub_key),
-				maid_signature: crypto::sign::Signature(maid_signature_arr),
-				owner: NameType::generate_random(),
-				signature: crypto::sign::Signature(signature_arr),
-				name: NameType::generate_random()
-			}
-		}
-	}
-
-#[test]
-	fn serialisation_public_maid() {
-		let obj_before = PublicMaid::generate_random();
-
-		let mut e = cbor::Encoder::from_memory();
-		e.encode(&[&obj_before]).unwrap();
-
-		let mut d = cbor::Decoder::from_bytes(e.as_bytes());
-		let obj_after: PublicMaid = d.decode().next().unwrap().unwrap();
-
-		assert_eq!(obj_before, obj_after);
-	}
+            PublicMaid {
+                public_keys: (sign_pub_key, asym_pub_key),
+                maid_signature: crypto::sign::Signature(maid_signature_arr),
+                owner: routing::test_utils::Random::generate_random(),
+                signature: crypto::sign::Signature(signature_arr),
+                name: routing::test_utils::Random::generate_random()
+            }
+        }
+    }
 
 #[test]
-	fn equality_assertion_public_maid() {
-		let public_maid_first = PublicMaid::generate_random();
-		let public_maid_second = public_maid_first.clone();
-		let public_maid_third = PublicMaid::generate_random();
-		assert_eq!(public_maid_first, public_maid_second);
-		assert!(public_maid_first != public_maid_third);
-	}
-	
+    fn serialisation_public_maid() {
+        let obj_before = PublicMaid::generate_random();
+
+        let mut e = cbor::Encoder::from_memory();
+        e.encode(&[&obj_before]).unwrap();
+
+        let mut d = cbor::Decoder::from_bytes(e.as_bytes());
+        let obj_after: PublicMaid = d.decode().next().unwrap().unwrap();
+
+        assert_eq!(obj_before, obj_after);
+    }
+
+#[test]
+    fn equality_assertion_public_maid() {
+        let public_maid_first = PublicMaid::generate_random();
+        let public_maid_second = public_maid_first.clone();
+        let public_maid_third = PublicMaid::generate_random();
+        assert_eq!(public_maid_first, public_maid_second);
+        assert!(public_maid_first != public_maid_third);
+    }
+    
 }

--- a/src/id/public_mpid.rs
+++ b/src/id/public_mpid.rs
@@ -17,7 +17,6 @@
 // of the MaidSafe Software.
 
 use cbor::CborTagEncode;
-use cbor;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use sodiumoxide::crypto;
 use helper::*;
@@ -111,6 +110,17 @@ impl fmt::Debug for PublicMpid {
 }
 
 impl PublicMpid {
+	/// An instance of the PublicMaid can be created by invoking the new function
+	///
+	/// #Examples
+	///
+	/// // Creating new PublicMpid
+	/// let public_mpid  = maidsafe_types::PublicMpid::new((pub_sign_key, pub_asym_key),
+	///                     sodiumoxide::crypto::sign::Signature([2u8; 64]),
+	///                     routing::name_type::NameType([8u8; 64]),
+	///                     sodiumoxide::crypto::sign::Signature([5u8; 64]),
+	///                    routing::name_type::NameType([6u8; 64]));
+	///
 	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
 						 mpid_signature: crypto::sign::Signature,
 						 owner: NameType,
@@ -124,22 +134,32 @@ impl PublicMpid {
 		name: name,
 		}
 	}
+
+	/// Returns the Symetric and Assymetric Publick keys
 	#[warn(dead_code)]
 	pub fn get_public_keys(& self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
 		&self.public_keys
 	}
+
+	/// Returns the Signature for the Mpid
 	#[warn(dead_code)]
 	pub fn get_mpid_signature(& self) -> &crypto::sign::Signature {
 		&self.mpid_signature
 	}
+
+	/// Returns the owner
 	#[warn(dead_code)]
 	pub fn get_owner(& self) -> &NameType {
 		&self.owner
 	}
+
+	/// Returns the PublicMpid Signature
 	#[warn(dead_code)]
 	pub fn get_signature(& self) -> &crypto::sign::Signature {
 		&self.signature
 	}
+
+	/// Returns the name for the PublicMpid
 	#[warn(dead_code)]
 	pub fn get_name(& self) -> &NameType {
 		&self.name

--- a/src/id/public_mpid.rs
+++ b/src/id/public_mpid.rs
@@ -24,9 +24,6 @@ use helper::*;
 use routing::name_type::NameType;
 use routing::message_interface::MessageInterface;
 use std::fmt;
-use Random;
-use std::mem;
-use rand;
 
 /// PublicMpid
 ///
@@ -113,27 +110,6 @@ impl fmt::Debug for PublicMpid {
     }
 }
 
-impl Random for PublicMpid {
-	fn generate_random() -> PublicMpid {
-        let (sign_pub_key, _) = crypto::sign::gen_keypair();
-        let (asym_pub_key, _) = crypto::asymmetricbox::gen_keypair();
-        let mut mpid_signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
-        let mut signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
-        for i in 0..64 {
-            mpid_signature_arr[i] = rand::random::<u8>();
-            signature_arr[i] = rand::random::<u8>();
-        }
-
-		PublicMpid {
-			public_keys: (sign_pub_key, asym_pub_key),
-			mpid_signature: crypto::sign::Signature(mpid_signature_arr),
-			owner: NameType::generate_random(),
-			signature: crypto::sign::Signature(signature_arr),
-			name: NameType::generate_random()
-		}
-	}
-}
-
 impl PublicMpid {
 	pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
 						 mpid_signature: crypto::sign::Signature,
@@ -208,24 +184,58 @@ impl Decodable for PublicMpid {
     }
 }
 
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cbor;
+    use sodiumoxide::crypto;
+    use routing::name_type::NameType;   
+    use Random;
+    use rand;
+    use std::mem;
+
+    impl Random for PublicMpid {
+		fn generate_random() -> PublicMpid {
+	        let (sign_pub_key, _) = crypto::sign::gen_keypair();
+	        let (asym_pub_key, _) = crypto::asymmetricbox::gen_keypair();
+	        let mut mpid_signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
+	        let mut signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
+	        for i in 0..64 {
+	            mpid_signature_arr[i] = rand::random::<u8>();
+	            signature_arr[i] = rand::random::<u8>();
+	        }
+
+			PublicMpid {
+				public_keys: (sign_pub_key, asym_pub_key),
+				mpid_signature: crypto::sign::Signature(mpid_signature_arr),
+				owner: NameType::generate_random(),
+				signature: crypto::sign::Signature(signature_arr),
+				name: NameType::generate_random()
+			}
+		}
+	}
+
+
 #[test]
-fn serialisation_public_mpid() {
-	let obj_before = PublicMpid::generate_random();
+	fn serialisation_public_mpid() {
+		let obj_before = PublicMpid::generate_random();
 
-	let mut e = cbor::Encoder::from_memory();
-	e.encode(&[&obj_before]).unwrap();
+		let mut e = cbor::Encoder::from_memory();
+		e.encode(&[&obj_before]).unwrap();
 
-	let mut d = cbor::Decoder::from_bytes(e.as_bytes());
-	let obj_after: PublicMpid = d.decode().next().unwrap().unwrap();
+		let mut d = cbor::Decoder::from_bytes(e.as_bytes());
+		let obj_after: PublicMpid = d.decode().next().unwrap().unwrap();
 
-	assert_eq!(obj_before, obj_after);
-}
+		assert_eq!(obj_before, obj_after);
+	}
 
 #[test]
-fn equality_assertion_public_mpid() {
-	let public_mpid_first = PublicMpid::generate_random();
-	let public_mpid_second = public_mpid_first.clone();
-	let public_mpid_third = PublicMpid::generate_random();
-	assert_eq!(public_mpid_first, public_mpid_second);
-	assert!(public_mpid_first != public_mpid_third);
+	fn equality_assertion_public_mpid() {
+		let public_mpid_first = PublicMpid::generate_random();
+		let public_mpid_second = public_mpid_first.clone();
+		let public_mpid_third = PublicMpid::generate_random();
+		assert_eq!(public_mpid_first, public_mpid_second);
+		assert!(public_mpid_first != public_mpid_third);
+	}
+	
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 //
 // See the Licences for the specific language governing permissions and limitations relating to use
 // of the MaidSafe Software.
-
 #![crate_name = "maidsafe_types"]
 #![crate_type = "lib"]
 #![doc(html_logo_url = "http://maidsafe.net/img/Resources/branding/maidsafe_logo.fab2.png",
@@ -29,16 +28,19 @@
 //! On disk serialisation is [JSON](https://www.ietf.org/rfc/rfc4627.txt)
 //!
 //! [Project github page](https://github.com/dirvine/maidsafe_types)
-
+#![deny(missing_docs)]
 extern crate rustc_serialize;
 extern crate sodiumoxide;
 extern crate cbor;
 extern crate rand;
 extern crate routing;
 
+/// Helper provides helper functions for array to vector conversions and vice versa
 #[macro_use]
 pub mod helper;
+/// Holds the structs for Id related Types such as Maid, AnMaid, Mpid, etc
 pub mod id;
+/// Holds the structs related to data such as ImmutableData and StructuredData
 pub mod data;
 
 pub use id::{Maid, Mpid, AnMaid, PublicAnMaid, AnMpid, PublicMaid, PublicMpid};
@@ -47,11 +49,15 @@ pub use data::{ImmutableData, StructuredData};
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
+/// Random trait is used to generate random instances.
+/// Used in the test mod
 pub trait Random {
+    /// Generates a random instance and returns the created random instance
     fn generate_random() -> Self;
 }
-
+/// Crypto Error types 
 pub enum CryptoError {
+    /// Unknown Error Type
     Unknown
 }
 
@@ -60,10 +66,15 @@ pub enum CryptoError {
 ///     MaidManager : PublicMaid, PublicAnMaid
 ///     All : Datatype -- ImmutableData, StructuredData
 pub enum PayloadTypeTag {
+  /// PublicMaid type
   PublicMaid,
+  /// PublicAnMaid type
   PublicAnMaid,
+  /// ImmutableData type
   ImmutableData,
+  /// StructuredData type
   StructuredData,
+  /// Unknown type
   Unknown
 }
 
@@ -118,28 +129,29 @@ impl Decodable for Payload {
 }
 
 impl Payload {
+  /// Creates an Instance of the Payload with empty payload and tag type passed as parameter.
   pub fn dummy_new(type_tag : PayloadTypeTag) -> Payload {
     Payload { type_tag: type_tag, payload: Vec::<u8>::new() }
   }
-
+  /// Creates an instance of the Payload
   pub fn new<T>(type_tag : PayloadTypeTag, data : &T) -> Payload where T: for<'a> Encodable + Decodable {
     let mut e = cbor::Encoder::from_memory();
     e.encode(&[data]).unwrap();
     Payload { type_tag: type_tag, payload: e.as_bytes().to_vec() }
   }
-
+  /// Returns the data
   pub fn get_data<T>(&self) -> T where T: for<'a> Encodable + Decodable {
     let mut d = cbor::Decoder::from_bytes(&self.payload[..]);
     let obj: T = d.decode().next().unwrap().unwrap();
     obj
   }
-
+  /// Set the data for the payload
   pub fn set_data<T>(&mut self, data: T) where T: for<'a> Encodable + Decodable {
     let mut e = cbor::Encoder::from_memory();
     e.encode(&[&data]).unwrap();
     self.payload = e.as_bytes().to_vec();
   }
-
+  /// Returns the PayloadTypeTag
   pub fn get_type_tag(&self) -> PayloadTypeTag {
     self.type_tag.clone()
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,95 +66,95 @@ pub enum CryptoError {
 ///     MaidManager : PublicMaid, PublicAnMaid
 ///     All : Datatype -- ImmutableData, StructuredData
 pub enum PayloadTypeTag {
-  /// PublicMaid type
-  PublicMaid,
-  /// PublicAnMaid type
-  PublicAnMaid,
-  /// ImmutableData type
-  ImmutableData,
-  /// StructuredData type
-  StructuredData,
-  /// Unknown type
-  Unknown
+    /// PublicMaid type
+    PublicMaid,
+    /// PublicAnMaid type
+    PublicAnMaid,
+    /// ImmutableData type
+    ImmutableData,
+    /// StructuredData type
+    StructuredData,
+    /// Unknown type
+    Unknown
 }
 
 impl Encodable for PayloadTypeTag {
-  fn encode<E: Encoder>(&self, e: &mut E)->Result<(), E::Error> {
-    let mut type_tag : &str;
-    match *self {
-      PayloadTypeTag::PublicMaid => type_tag = "PublicMaid",
-      PayloadTypeTag::PublicAnMaid => type_tag = "PublicAnMaid",
-      PayloadTypeTag::ImmutableData => type_tag = "ImmutableData",
-      PayloadTypeTag::StructuredData => type_tag = "StructuredData",
-      PayloadTypeTag::Unknown => type_tag = "Unknown",
-    };
-    CborTagEncode::new(5483_100, &(&type_tag)).encode(e)
-  }
+    fn encode<E: Encoder>(&self, e: &mut E)->Result<(), E::Error> {
+        let mut type_tag : &str;
+        match *self {
+          PayloadTypeTag::PublicMaid => type_tag = "PublicMaid",
+          PayloadTypeTag::PublicAnMaid => type_tag = "PublicAnMaid",
+          PayloadTypeTag::ImmutableData => type_tag = "ImmutableData",
+          PayloadTypeTag::StructuredData => type_tag = "StructuredData",
+          PayloadTypeTag::Unknown => type_tag = "Unknown",
+        };
+        CborTagEncode::new(5483_100, &(&type_tag)).encode(e)
+    }
 }
 
 impl Decodable for PayloadTypeTag {
-  fn decode<D: Decoder>(d: &mut D)->Result<PayloadTypeTag, D::Error> {
-    try!(d.read_u64());
-    let mut type_tag : String;
-    type_tag = try!(Decodable::decode(d));
-    match &type_tag[..] {
-      "PublicMaid" => Ok(PayloadTypeTag::PublicMaid),
-      "PublicAnMaid" => Ok(PayloadTypeTag::PublicAnMaid),
-      "ImmutableData" => Ok(PayloadTypeTag::ImmutableData),
-      "StructuredData" => Ok(PayloadTypeTag::StructuredData),
-      _ => Ok(PayloadTypeTag::Unknown)
+    fn decode<D: Decoder>(d: &mut D)->Result<PayloadTypeTag, D::Error> {
+        try!(d.read_u64());
+        let mut type_tag : String;
+        type_tag = try!(Decodable::decode(d));
+        match &type_tag[..] {
+          "PublicMaid" => Ok(PayloadTypeTag::PublicMaid),
+          "PublicAnMaid" => Ok(PayloadTypeTag::PublicAnMaid),
+          "ImmutableData" => Ok(PayloadTypeTag::ImmutableData),
+          "StructuredData" => Ok(PayloadTypeTag::StructuredData),
+          _ => Ok(PayloadTypeTag::Unknown)
+        }
     }
-  }
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 /// Encoded type serialised and ready to send on wire
 pub struct Payload {
-  type_tag : PayloadTypeTag,
-  payload : Vec<u8>
+    type_tag : PayloadTypeTag,
+    payload : Vec<u8>
 }
 
 impl Encodable for Payload {
-  fn encode<E: Encoder>(&self, e: &mut E)->Result<(), E::Error> {
-    CborTagEncode::new(5483_001, &(&self.type_tag, &self.payload)).encode(e)
-  }
+    fn encode<E: Encoder>(&self, e: &mut E)->Result<(), E::Error> {
+        CborTagEncode::new(5483_001, &(&self.type_tag, &self.payload)).encode(e)
+    }
 }
 
 impl Decodable for Payload {
-  fn decode<D: Decoder>(d: &mut D)->Result<Payload, D::Error> {
-    try!(d.read_u64());
-    let (type_tag, payload) = try!(Decodable::decode(d));
-    Ok(Payload { type_tag: type_tag, payload: payload })
-  }
+    fn decode<D: Decoder>(d: &mut D)->Result<Payload, D::Error> {
+        try!(d.read_u64());
+        let (type_tag, payload) = try!(Decodable::decode(d));
+        Ok(Payload { type_tag: type_tag, payload: payload })
+    }
 }
 
 impl Payload {
-  /// Creates an Instance of the Payload with empty payload and tag type passed as parameter.
-  pub fn dummy_new(type_tag : PayloadTypeTag) -> Payload {
-    Payload { type_tag: type_tag, payload: Vec::<u8>::new() }
-  }
-  /// Creates an instance of the Payload
-  pub fn new<T>(type_tag : PayloadTypeTag, data : &T) -> Payload where T: for<'a> Encodable + Decodable {
-    let mut e = cbor::Encoder::from_memory();
-    e.encode(&[data]).unwrap();
-    Payload { type_tag: type_tag, payload: e.as_bytes().to_vec() }
-  }
-  /// Returns the data
-  pub fn get_data<T>(&self) -> T where T: for<'a> Encodable + Decodable {
-    let mut d = cbor::Decoder::from_bytes(&self.payload[..]);
-    let obj: T = d.decode().next().unwrap().unwrap();
-    obj
-  }
-  /// Set the data for the payload
-  pub fn set_data<T>(&mut self, data: T) where T: for<'a> Encodable + Decodable {
-    let mut e = cbor::Encoder::from_memory();
-    e.encode(&[&data]).unwrap();
-    self.payload = e.as_bytes().to_vec();
-  }
-  /// Returns the PayloadTypeTag
-  pub fn get_type_tag(&self) -> PayloadTypeTag {
-    self.type_tag.clone()
-  }
+    /// Creates an Instance of the Payload with empty payload and tag type passed as parameter.
+    pub fn dummy_new(type_tag : PayloadTypeTag) -> Payload {
+        Payload { type_tag: type_tag, payload: Vec::<u8>::new() }
+    }
+    /// Creates an instance of the Payload
+    pub fn new<T>(type_tag : PayloadTypeTag, data : &T) -> Payload where T: for<'a> Encodable + Decodable {
+        let mut e = cbor::Encoder::from_memory();
+        e.encode(&[data]).unwrap();
+        Payload { type_tag: type_tag, payload: e.as_bytes().to_vec() }
+    }
+    /// Returns the data
+    pub fn get_data<T>(&self) -> T where T: for<'a> Encodable + Decodable {
+        let mut d = cbor::Decoder::from_bytes(&self.payload[..]);
+        let obj: T = d.decode().next().unwrap().unwrap();
+        obj
+    }
+    /// Set the data for the payload
+    pub fn set_data<T>(&mut self, data: T) where T: for<'a> Encodable + Decodable {
+        let mut e = cbor::Encoder::from_memory();
+        e.encode(&[&data]).unwrap();
+        self.payload = e.as_bytes().to_vec();
+    }
+    /// Returns the PayloadTypeTag
+    pub fn get_type_tag(&self) -> PayloadTypeTag {
+        self.type_tag.clone()
+    }
 }
 #[test]
 fn dummy()  {


### PR DESCRIPTION
maid and an_maid files have not been re-factored. Because both the types do not have a 'new' method to create an instance. Instead, generate_random() has been used. Examples also use generate_random() for creating a new instance. Thus leaving that untouched assuming, maid and an_maid instances can be created only via 'generate_random()'

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/maidsafe_types/34)

<!-- Reviewable:end -->
