### PR TITLE
adds pure sign public key to dependent keys

### DIFF
--- a/src/data/structured_data.rs
+++ b/src/data/structured_data.rs
@@ -13,7 +13,7 @@
 // KIND, either express or implied.
 //
 // Please review the Licences for the specific language governing permissions and limitations
-// relating to use of the SAFE Network Software. 
+// relating to use of the SAFE Network Software.
 
 use cbor;
 use cbor::CborTagEncode;
@@ -31,7 +31,7 @@ pub struct StructuredData {
 
 impl Sendable for StructuredData {
     fn name(&self) -> NameType {
-             self.name.clone()
+        self.name.clone()
     }
 
     fn type_tag(&self)->u64 {
@@ -41,13 +41,9 @@ impl Sendable for StructuredData {
     fn serialised_contents(&self)->Vec<u8> {
         let mut e = cbor::Encoder::from_memory();
         e.encode(&[&self]).unwrap();
-        e.into_bytes()      
+        e.into_bytes()
     }
 
-    fn owner(&self) -> Option<NameType> {
-        Some(self.owner.clone())
-    }
-    
     fn refresh(&self)->bool {
         false
     }
@@ -73,6 +69,11 @@ impl StructuredData {
     /// Sets the value
     pub fn set_value(&mut self, data: Vec<Vec<NameType>>) {
         self.value = data;
+    }
+
+    /// Returns the owner
+    pub fn get_owner(&self) -> NameType {
+        self.owner.clone()
     }
 }
 
@@ -100,7 +101,7 @@ mod test {
     use cbor::{ Encoder, Decoder };
     use rustc_serialize::{Decodable, Encodable};
     use routing;
-    use routing::NameType;    
+    use routing::NameType;
     use routing::sendable::Sendable;
     use Random;
     use rand;
@@ -127,8 +128,8 @@ mod test {
 
 #[test]
     fn creation() {
-        let structured_data = StructuredData::generate_random();        
-        let data = StructuredData::new(structured_data.name(), structured_data.owner().unwrap(), structured_data.get_value());        
+        let structured_data = StructuredData::generate_random();
+        let data = StructuredData::new(structured_data.name(), structured_data.get_owner(), structured_data.get_value());
         assert_eq!(data, structured_data);
     }
 

--- a/src/id/an_mpid.rs
+++ b/src/id/an_mpid.rs
@@ -13,7 +13,7 @@
 // KIND, either express or implied.
 //
 // Please review the Licences for the specific language governing permissions and limitations
-// relating to use of the SAFE Network Software. 
+// relating to use of the SAFE Network Software.
 
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -76,11 +76,7 @@ impl Sendable for AnMpid {
     fn serialised_contents(&self)->Vec<u8> {
         let mut e = cbor::Encoder::from_memory();
         e.encode(&[&self]).unwrap();
-        e.into_bytes()      
-    }
-
-    fn owner(&self) -> Option<NameType> {
-        Some(self.name.clone())
+        e.into_bytes()
     }
 
     fn refresh(&self)->bool {
@@ -207,5 +203,5 @@ mod test {
         assert_eq!(an_mpid_first, an_mpid_second);
         assert!(an_mpid_first != an_mpid_third);
     }
-    
+
 }

--- a/src/id/public_maid.rs
+++ b/src/id/public_maid.rs
@@ -13,7 +13,7 @@
 // KIND, either express or implied.
 //
 // Please review the Licences for the specific language governing permissions and limitations
-// relating to use of the SAFE Network Software. 
+// relating to use of the SAFE Network Software.
 
 use cbor;
 use cbor::CborTagEncode;
@@ -36,13 +36,13 @@ use std::fmt;
 /// // Generating sign and asymmetricbox keypairs,
 /// let (pub_sign_key, _) = sodiumoxide::crypto::sign::gen_keypair(); // returns (PublicKey, SecretKey)
 /// let (pub_asym_key, _) = sodiumoxide::crypto::asymmetricbox::gen_keypair();
+/// let (owner_pub_sign_key, _) = sodiumoxide::crypto::sign::gen_keypair();
 ///
 /// // Creating new PublicMaid
 /// let public_maid  = maidsafe_types::PublicMaid::new((pub_sign_key, pub_asym_key),
 ///                     sodiumoxide::crypto::sign::Signature([2u8; 64]),
-///                     routing::NameType([8u8; 64]),
-///                     sodiumoxide::crypto::sign::Signature([5u8; 64]),
-///                     routing::NameType([6u8; 64]));
+///                     owner_pub_sign_key,
+///                     sodiumoxide::crypto::sign::Signature([5u8; 64]));
 ///
 /// // getting PublicMaid::public_keys
 /// let &(pub_sign, pub_asym) = public_maid.get_public_keys();
@@ -50,23 +50,22 @@ use std::fmt;
 /// // getting PublicMaid::mpid_signature
 /// let maid_signature: &sodiumoxide::crypto::sign::Signature = public_maid.get_maid_signature();
 ///
-/// // getting PublicMaid::owner
-/// let owner: &routing::NameType = public_maid.get_owner();
+/// // getting PublicMaid::owner_pub_sign_key
+/// let owner_pub_sign_key: &sodiumoxide::crypto::sign::PublicKey = public_maid.get_owner_sign_public_key();
 ///
 /// // getting PublicMaid::signature
 /// let signature: &sodiumoxide::crypto::sign::Signature = public_maid.get_signature();
 ///
 /// // getting PublicMaid::name
-/// let name: &routing::NameType = public_maid.get_name();
+/// let name: routing::NameType = public_maid.get_name();
 /// ```
 
 #[derive(Clone)]
 pub struct PublicMaid {
     public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
     maid_signature: crypto::sign::Signature,
-    owner: NameType,
+    owner_sign_public_key: crypto::sign::PublicKey,
     signature: crypto::sign::Signature,
-    name: NameType
 }
 
 impl Sendable for PublicMaid {
@@ -95,13 +94,13 @@ impl Sendable for PublicMaid {
     fn serialised_contents(&self)->Vec<u8> {
         let mut e = cbor::Encoder::from_memory();
         e.encode(&[&self]).unwrap();
-        e.into_bytes()      
+        e.into_bytes()
     }
 
-    fn owner(&self) -> Option<NameType> {
-        Some(self.owner.clone())
+    fn owner_sign_public_key(&self) -> Option<crypto::sign::PublicKey> {
+        Some(self.owner_sign_public_key.clone())
     }
-    
+
     fn refresh(&self)->bool {
         false
     }
@@ -115,14 +114,14 @@ impl PartialEq for PublicMaid {
         let pub2_equal = slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0);
         let sig1_equal = slice_equal(&self.maid_signature.0, &other.maid_signature.0);
         let sig2_equal = slice_equal(&self.signature.0, &other.signature.0);
-        return pub1_equal && pub2_equal && sig1_equal && sig2_equal && self.name == other.name;
+        return pub1_equal && pub2_equal && sig1_equal && sig2_equal;
     }
 }
 
 impl fmt::Debug for PublicMaid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "PublicMaid {{ public_keys:({:?}, {:?}), maid_signature:{:?}, owner:{:?}, signature:{:?}, name: {:?} }}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
-            self.maid_signature.0.to_vec(), self.owner, self.signature.0.to_vec(), self.name)
+            self.maid_signature.0.to_vec(), self.owner_sign_public_key.0.to_vec(), self.signature.0.to_vec(), self.name())
     }
 }
 
@@ -130,15 +129,13 @@ impl PublicMaid {
     /// An instanstance of the PublicMaid can be created using the new()
     pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
                          maid_signature: crypto::sign::Signature,
-                         owner: NameType,
-                         signature: crypto::sign::Signature,
-                         name: NameType) -> PublicMaid {
+                         owner_sign_public_key: crypto::sign::PublicKey,
+                         signature: crypto::sign::Signature) -> PublicMaid {
         PublicMaid {
         public_keys: public_keys,
         maid_signature: maid_signature,
-        owner: owner,
-        signature: signature,
-        name: name,
+        owner_sign_public_key: owner_sign_public_key,
+        signature: signature
         }
     }
     /// Returns the PublicKeys
@@ -150,16 +147,16 @@ impl PublicMaid {
         &self.maid_signature
     }
     /// Returns the Owner
-    pub fn get_owner(&self) -> &NameType {
-        &self.owner
+    pub fn get_owner_sign_public_key(&self) -> &crypto::sign::PublicKey {
+        &self.owner_sign_public_key
     }
     /// Returns the Signature of PublicMaid
     pub fn get_signature(&self) -> &crypto::sign::Signature {
         &self.signature
     }
     /// Returns the Name
-    pub fn get_name(&self) -> &NameType {
-        &self.name
+    pub fn get_name(&self) -> NameType {
+        self.name().clone()
     }
 }
 
@@ -168,25 +165,26 @@ impl Encodable for PublicMaid {
         let (crypto::sign::PublicKey(ref pub_sign_vec), crypto::asymmetricbox::PublicKey(pub_asym_vec)) = self.public_keys;
         let crypto::sign::Signature(ref maid_signature) = self.maid_signature;
         let crypto::sign::Signature(ref signature) = self.signature;
+        let crypto::sign::PublicKey(ref owner_pub_sign_vec) = self.owner_sign_public_key;
         CborTagEncode::new(5483_001, &(
             pub_sign_vec.as_ref(),
             pub_asym_vec.as_ref(),
             maid_signature.as_ref(),
-            &self.owner,
-            signature.as_ref(),
-            &self.name)).encode(e)
+            owner_pub_sign_vec.as_ref(),
+            signature.as_ref())).encode(e)
     }
 }
 
 impl Decodable for PublicMaid {
     fn decode<D: Decoder>(d: &mut D)-> Result<PublicMaid, D::Error> {
     try!(d.read_u64());
-    let (pub_sign_vec, pub_asym_vec, maid_signature_vec, owner, signature_vec, name) : (Vec<u8>, Vec<u8>, Vec<u8>, NameType, Vec<u8>, NameType) = try!(Decodable::decode(d));
+    let (pub_sign_vec, pub_asym_vec, maid_signature_vec, owner_sign_pub_vec, signature_vec) : (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) = try!(Decodable::decode(d));
 
         let pub_sign_arr = convert_to_array!(pub_sign_vec, crypto::sign::PUBLICKEYBYTES);
         let pub_asym_arr = convert_to_array!(pub_asym_vec, crypto::asymmetricbox::PUBLICKEYBYTES);
         let maid_signature_arr = convert_to_array!(maid_signature_vec, crypto::sign::SIGNATUREBYTES);
         let signature_arr = convert_to_array!(signature_vec, crypto::sign::SIGNATUREBYTES);
+        let owner_sign_pub_arr = convert_to_array!(owner_sign_pub_vec, crypto::sign::PUBLICKEYBYTES);
 
         if pub_sign_arr.is_none() || pub_asym_arr.is_none() || maid_signature_arr.is_none() || signature_arr.is_none() {
             return Err(d.error("Bad PublicMaid size"));
@@ -196,8 +194,9 @@ impl Decodable for PublicMaid {
             crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
     let parsed_maid_signature = crypto::sign::Signature(maid_signature_arr.unwrap());
     let parsed_signature = crypto::sign::Signature(signature_arr.unwrap());
+    let owner_sign_public_key = crypto::sign::PublicKey(owner_sign_pub_arr.unwrap());
 
-    Ok(PublicMaid::new(pub_keys, parsed_maid_signature, owner, parsed_signature, name))
+    Ok(PublicMaid::new(pub_keys, parsed_maid_signature, owner_sign_public_key, parsed_signature))
     }
 }
 
@@ -217,6 +216,7 @@ mod test {
             let (asym_pub_key, _) = crypto::asymmetricbox::gen_keypair();
             let mut maid_signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
             let mut signature_arr: [u8; 64] = unsafe { mem::uninitialized() };
+            let (owner_sign_pub_key, _) = crypto::sign::gen_keypair();
             for i in 0..64 {
                 maid_signature_arr[i] = rand::random::<u8>();
                 signature_arr[i] = rand::random::<u8>();
@@ -225,9 +225,8 @@ mod test {
             PublicMaid {
                 public_keys: (sign_pub_key, asym_pub_key),
                 maid_signature: crypto::sign::Signature(maid_signature_arr),
-                owner: routing::test_utils::Random::generate_random(),
-                signature: crypto::sign::Signature(signature_arr),
-                name: routing::test_utils::Random::generate_random()
+                owner_sign_public_key: owner_sign_pub_key,
+                signature: crypto::sign::Signature(signature_arr)
             }
         }
     }
@@ -253,5 +252,5 @@ mod test {
         assert_eq!(public_maid_first, public_maid_second);
         assert!(public_maid_first != public_maid_third);
     }
-    
+
 }


### PR DESCRIPTION
1- Adds owner_sign_public_key to dependent types
2- Removes owner from types
3- Removes the name field from types, while providing methods to get name using other fields

Notes: 1- In dependent keys there are two signature. one may be unnecessary.
            2- compiling this requires using 'type' branch of routing. a PR to routing
