### PR TITLE
Maid 1029: Removes name as a member variable from types

### DIFF
--- a/src/data/immutable_data.rs
+++ b/src/data/immutable_data.rs
@@ -13,7 +13,7 @@
 // KIND, either express or implied.
 //
 // Please review the Licences for the specific language governing permissions and limitations
-// relating to use of the SAFE Network Software. 
+// relating to use of the SAFE Network Software.
 
 use cbor;
 use cbor::CborTagEncode;
@@ -41,7 +41,7 @@ impl Sendable for ImmutableData {
     fn serialised_contents(&self)->Vec<u8> {
         let mut e = cbor::Encoder::from_memory();
         e.encode(&[&self]).unwrap();
-        e.into_bytes()      
+        e.into_bytes()
     }
 
     fn refresh(&self)->bool {
@@ -102,7 +102,7 @@ mod test {
     use super::*;
     use cbor::{ Encoder, Decoder};
     use rustc_serialize::{Decodable, Encodable};
-    use Random;    
+    use Random;
     use rand;
     use routing::sendable::Sendable;
 
@@ -142,7 +142,7 @@ mod test {
         let mut d = Decoder::from_bytes(e.as_bytes());
         let obj_after: ImmutableData = d.decode().next().unwrap().unwrap();
 
-        assert_eq!(obj_before, obj_after);        
+        assert_eq!(obj_before, obj_after);
     }
 
     #[test]

--- a/src/data/structured_data.rs
+++ b/src/data/structured_data.rs
@@ -13,7 +13,7 @@
 // KIND, either express or implied.
 //
 // Please review the Licences for the specific language governing permissions and limitations
-// relating to use of the SAFE Network Software. 
+// relating to use of the SAFE Network Software.
 
 use cbor;
 use cbor::CborTagEncode;
@@ -31,7 +31,7 @@ pub struct StructuredData {
 
 impl Sendable for StructuredData {
     fn name(&self) -> NameType {
-             self.name.clone()
+        self.name.clone()
     }
 
     fn type_tag(&self)->u64 {
@@ -41,13 +41,13 @@ impl Sendable for StructuredData {
     fn serialised_contents(&self)->Vec<u8> {
         let mut e = cbor::Encoder::from_memory();
         e.encode(&[&self]).unwrap();
-        e.into_bytes()      
+        e.into_bytes()
     }
 
     fn owner(&self) -> Option<NameType> {
         Some(self.owner.clone())
     }
-    
+
     fn refresh(&self)->bool {
         false
     }
@@ -58,11 +58,7 @@ impl Sendable for StructuredData {
 impl StructuredData {
     /// An instance of the StructuredData can be created by invoking the new()
     pub fn new(name: NameType, owner: NameType, value: Vec<Vec<NameType>>) -> StructuredData {
-        StructuredData {
-            name: name,
-            owner: owner,
-            value: value,
-        }
+        StructuredData {name: name, owner: owner, value: value}
     }
 
     /// Returns the value
@@ -100,7 +96,7 @@ mod test {
     use cbor::{ Encoder, Decoder };
     use rustc_serialize::{Decodable, Encodable};
     use routing;
-    use routing::NameType;    
+    use routing::NameType;
     use routing::sendable::Sendable;
     use Random;
     use rand;
@@ -127,8 +123,8 @@ mod test {
 
 #[test]
     fn creation() {
-        let structured_data = StructuredData::generate_random();        
-        let data = StructuredData::new(structured_data.name(), structured_data.owner().unwrap(), structured_data.get_value());        
+        let structured_data = StructuredData::generate_random();
+        let data = StructuredData::new(structured_data.name(), structured_data.owner().unwrap(), structured_data.get_value());
         assert_eq!(data, structured_data);
     }
 

--- a/src/data/structured_data.rs
+++ b/src/data/structured_data.rs
@@ -24,6 +24,7 @@ use routing::sendable::Sendable;
 /// StructuredData
 #[derive(Clone, PartialEq, Debug)]
 pub struct StructuredData {
+    type_tag: u64,
     name: NameType,
     owner: NameType,
     value: Vec<Vec<NameType>>,
@@ -35,7 +36,7 @@ impl Sendable for StructuredData {
     }
 
     fn type_tag(&self)->u64 {
-        102
+        self.type_tag.clone()
     }
 
     fn serialised_contents(&self)->Vec<u8> {
@@ -58,11 +59,11 @@ impl Sendable for StructuredData {
 impl StructuredData {
     /// An instance of the StructuredData can be created by invoking the new()
     pub fn new(name: NameType, owner: NameType, value: Vec<Vec<NameType>>) -> StructuredData {
-        StructuredData {name: name, owner: owner, value: value}
+        StructuredData {type_tag: 100u64, name: name, owner: owner, value: value}
     }
 
     /// Returns the value
-    pub fn get_value(&self) -> Vec<Vec<NameType>> {
+    pub fn value(&self) -> Vec<Vec<NameType>> {
         self.value.clone()
     }
 
@@ -83,6 +84,7 @@ impl Decodable for StructuredData {
         try!(d.read_u64());
         let (name, owner, value) = try!(Decodable::decode(d));
         let structured = StructuredData {
+            type_tag: 100u64,
             name: name,
             owner: owner,
             value: value
@@ -114,6 +116,7 @@ mod test {
                 outer.push(inner);
             }
             StructuredData {
+                type_tag: 100u64,
                 name: routing::test_utils::Random::generate_random(),
                 owner: routing::test_utils::Random::generate_random(),
                 value: outer,
@@ -124,7 +127,7 @@ mod test {
 #[test]
     fn creation() {
         let structured_data = StructuredData::generate_random();
-        let data = StructuredData::new(structured_data.name(), structured_data.owner().unwrap(), structured_data.get_value());
+        let data = StructuredData::new(structured_data.name(), structured_data.owner().unwrap(), structured_data.value());
         assert_eq!(data, structured_data);
     }
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -13,7 +13,10 @@
 // KIND, either express or implied.
 //
 // Please review the Licences for the specific language governing permissions and limitations
-// relating to use of the SAFE Network Software. 
+// relating to use of the SAFE Network Software.
+
+use sodiumoxide::crypto;
+use routing::NameType;
 
 ///
 /// Returns true if both slices are equal in length, and have equal contents
@@ -47,6 +50,18 @@ macro_rules! convert_to_array {
             Some(arr)
         }
     }};
+}
+
+///
+/// Calculate and returns NameType using Public signing & encryption kets
+///
+pub fn calculate_name(public_keys: &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey)) -> NameType {
+    let combined_iter = (public_keys.0).0.into_iter().chain((public_keys.1).0.into_iter());
+    let mut combined: Vec<u8> = Vec::new();
+    for iter in combined_iter {
+        combined.push(*iter);
+    }
+    NameType(crypto::hash::sha512::hash(&combined).0)
 }
 
 #[cfg(test)]

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -55,7 +55,7 @@ macro_rules! convert_to_array {
 ///
 /// Calculate and returns NameType using Public signing & encryption kets
 ///
-pub fn calculate_name(public_keys: &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey)) -> NameType {
+pub fn name(public_keys: &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey)) -> NameType {
     let combined_iter = (public_keys.0).0.into_iter().chain((public_keys.1).0.into_iter());
     let mut combined: Vec<u8> = Vec::new();
     for iter in combined_iter {

--- a/src/id/an_mpid.rs
+++ b/src/id/an_mpid.rs
@@ -107,12 +107,7 @@ impl AnMpid {
     }
     /// Returns the name
     pub fn get_name(&self) -> NameType {
-        let combined_iter = (self.public_keys.0).0.into_iter().chain((self.public_keys.1).0.into_iter()).collect::<Vec<_>>();
-        let mut combined: Vec<u8> = Vec::new();
-        for iter in combined_iter {
-            combined.push(*iter);
-        }
-        NameType(crypto::hash::sha512::hash(&combined).0)
+        calculate_name(&self.public_keys)
     }
 }
 

--- a/src/id/an_mpid.rs
+++ b/src/id/an_mpid.rs
@@ -13,7 +13,7 @@
 // KIND, either express or implied.
 //
 // Please review the Licences for the specific language governing permissions and limitations
-// relating to use of the SAFE Network Software. 
+// relating to use of the SAFE Network Software.
 
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -36,37 +36,22 @@ use cbor;
 /// let (pub_sign_key, sec_sign_key) = sodiumoxide::crypto::sign::gen_keypair();
 /// let (pub_asym_key, sec_asym_key) = sodiumoxide::crypto::asymmetricbox::gen_keypair();
 /// // Create AnMpid
-/// let an_mpid = maidsafe_types::AnMpid::new((pub_sign_key, pub_asym_key), (sec_sign_key, sec_asym_key), routing::NameType([3u8; 64]));
+/// let an_mpid = maidsafe_types::AnMpid::new((pub_sign_key, pub_asym_key), (sec_sign_key, sec_asym_key));
 /// // Retrieving the values
 /// let ref publicKeys = an_mpid.get_public_keys();
 /// let ref secret_keys = an_mpid.get_secret_keys();
-/// let ref name = an_mpid.get_name();
+/// let name = an_mpid.get_name();
 /// ```
 ///
 #[derive(Clone)]
 pub struct AnMpid {
     public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
-    secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
-    name: NameType,
+    secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey)
 }
 
 impl Sendable for AnMpid {
     fn name(&self) -> NameType {
-        let sign_arr = &(&self.public_keys.0).0;
-        let asym_arr = &(&self.public_keys.1).0;
-
-        let mut arr_combined = [0u8; 64 * 2];
-
-        for i in 0..sign_arr.len() {
-            arr_combined[i] = sign_arr[i];
-        }
-        for i in 0..asym_arr.len() {
-            arr_combined[64 + i] = asym_arr[i];
-        }
-
-        let digest = crypto::hash::sha512::hash(&arr_combined);
-
-        NameType(digest.0)
+        self.get_name()
     }
 
     fn type_tag(&self)->u64 {
@@ -76,11 +61,11 @@ impl Sendable for AnMpid {
     fn serialised_contents(&self)->Vec<u8> {
         let mut e = cbor::Encoder::from_memory();
         e.encode(&[&self]).unwrap();
-        e.into_bytes()      
+        e.into_bytes()
     }
 
     fn owner(&self) -> Option<NameType> {
-        Some(self.name.clone())
+        Some(self.name().clone())
     }
 
     fn refresh(&self)->bool {
@@ -92,8 +77,8 @@ impl Sendable for AnMpid {
 
 impl fmt::Debug for AnMpid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "AnMpid {{ public_keys:({:?}, {:?}), secret_keys:({:?}, {:?}), name: {:?} }}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
-            self.secret_keys.0 .0.to_vec(), self.secret_keys.1 .0.to_vec(), self.name)
+        write!(f, "AnMpid {{ public_keys:({:?}, {:?}), secret_keys:({:?}, {:?}) }}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
+            self.secret_keys.0 .0.to_vec(), self.secret_keys.1 .0.to_vec())
     }
 }
 
@@ -102,20 +87,15 @@ impl PartialEq for AnMpid {
         // secret keys are mathematically linked, just check public ones
         let pub1_equal = slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0);
         let pub2_equal = slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0);
-        return pub1_equal && pub2_equal && self.name == other.name;
+        return pub1_equal && pub2_equal;
     }
 }
 
 impl AnMpid {
     /// Invoked to create an instance of AnMpid
     pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
-                         secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
-                         name_type: NameType) -> AnMpid {
-        AnMpid {
-        public_keys: public_keys,
-        secret_keys: secret_keys,
-        name: name_type
-        }
+                         secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey)) -> AnMpid {
+        AnMpid {public_keys: public_keys, secret_keys: secret_keys }
     }
     /// Returns the PublicKeys
     pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
@@ -126,8 +106,13 @@ impl AnMpid {
         &self.secret_keys
     }
     /// Returns the name
-    pub fn get_name(&self) -> &NameType {
-        &self.name
+    pub fn get_name(&self) -> NameType {
+        let combined_iter = (self.public_keys.0).0.into_iter().chain((self.public_keys.1).0.into_iter()).collect::<Vec<_>>();
+        let mut combined: Vec<u8> = Vec::new();
+        for iter in combined_iter {
+            combined.push(*iter);
+        }
+        NameType(crypto::hash::sha512::hash(&combined).0)
     }
 }
 
@@ -140,15 +125,14 @@ impl Encodable for AnMpid {
         pub_sign_vec.as_ref(),
         pub_asym_vec.as_ref(),
         sec_sign_vec.as_ref(),
-        sec_asym_vec.as_ref(),
-        &self.name)).encode(e)
+        sec_asym_vec.as_ref())).encode(e)
     }
 }
 
 impl Decodable for AnMpid {
     fn decode<D: Decoder>(d: &mut D)-> Result<AnMpid, D::Error> {
     try!(d.read_u64());
-    let (pub_sign_vec, pub_asym_vec, sec_sign_vec, sec_asym_vec, name) : (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, NameType) = try!(Decodable::decode(d));
+    let (pub_sign_vec, pub_asym_vec, sec_sign_vec, sec_asym_vec) : (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) = try!(Decodable::decode(d));
 
         let pub_sign_arr = convert_to_array!(pub_sign_vec, crypto::sign::PUBLICKEYBYTES);
         let pub_asym_arr = convert_to_array!(pub_asym_vec, crypto::asymmetricbox::PUBLICKEYBYTES);
@@ -163,7 +147,7 @@ impl Decodable for AnMpid {
             crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
     let sec_keys = (crypto::sign::SecretKey(sec_sign_arr.unwrap()),
             crypto::asymmetricbox::SecretKey(sec_asym_arr.unwrap()));
-    Ok(AnMpid::new(pub_keys, sec_keys, name))
+    Ok(AnMpid::new(pub_keys, sec_keys))
     }
 }
 
@@ -173,7 +157,6 @@ mod test {
     use cbor::{ Encoder, Decoder };
     use Random;
     use sodiumoxide::crypto;
-    use routing;
 
     impl Random for AnMpid {
         fn generate_random() -> AnMpid {
@@ -182,7 +165,6 @@ mod test {
             AnMpid {
                 public_keys: (sign_pub_key, asym_pub_key),
                 secret_keys: (sign_sec_key, asym_sec_key),
-                name: routing::test_utils::Random::generate_random()
             }
         }
     }
@@ -207,5 +189,5 @@ mod test {
         assert_eq!(an_mpid_first, an_mpid_second);
         assert!(an_mpid_first != an_mpid_third);
     }
-    
+
 }

--- a/src/id/an_mpid.rs
+++ b/src/id/an_mpid.rs
@@ -40,7 +40,6 @@ use cbor;
 /// // Retrieving the values
 /// let ref publicKeys = an_mpid.get_public_keys();
 /// let ref secret_keys = an_mpid.get_secret_keys();
-/// let name = an_mpid.get_name();
 /// ```
 ///
 #[derive(Clone)]
@@ -51,7 +50,7 @@ pub struct AnMpid {
 
 impl Sendable for AnMpid {
     fn name(&self) -> NameType {
-        self.get_name()
+        name(&self.public_keys)
     }
 
     fn type_tag(&self)->u64 {
@@ -104,10 +103,6 @@ impl AnMpid {
     /// Returns the SecretKeys
     pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
         &self.secret_keys
-    }
-    /// Returns the name
-    pub fn get_name(&self) -> NameType {
-        calculate_name(&self.public_keys)
     }
 }
 

--- a/src/id/maid.rs
+++ b/src/id/maid.rs
@@ -13,7 +13,7 @@
 // KIND, either express or implied.
 //
 // Please review the Licences for the specific language governing permissions and limitations
-// relating to use of the SAFE Network Software. 
+// relating to use of the SAFE Network Software.
 
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -27,7 +27,6 @@ use std::fmt;
 ///
 /// #Examples
 /// ```
-/// use maidsafe_types::Random;
 /// use maidsafe_types::{Maid, AnMaid};
 /// // Creating new Maid
 /// let maid: Maid  = Maid::new(&AnMaid::new());
@@ -45,7 +44,7 @@ pub struct Maid {
 impl Maid {
     /// Invoked to create an instance of Maid
     /// Symmetric public and secret keys of AnMaid and used to construct the Maid
-    pub fn new(an_maid: &AnMaid) -> Maid {        
+    pub fn new(an_maid: &AnMaid) -> Maid {
         let asym_keys = crypto::asymmetricbox::gen_keypair();
 
         Maid {
@@ -134,7 +133,7 @@ mod test {
     use super::super::AnMaid;
     use sodiumoxide::crypto;
     use Random;
-    use rand;    
+    use rand;
     use rand::Rng;
 
     impl Random for Maid {

--- a/src/id/maid.rs
+++ b/src/id/maid.rs
@@ -32,11 +32,12 @@ use std::fmt;
 /// let maid: Maid  = Maid::new(&AnMaid::new());
 ///
 /// // getting Maid::public_keys
-/// let &(pub_sign, pub_asym) = maid.get_public_keys();
+/// let &(pub_sign, pub_asym) = maid.public_keys();
 ///
 /// ```
 #[derive(Clone)]
 pub struct Maid {
+    type_tag: u64,
     public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
     secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey)
 }
@@ -48,12 +49,13 @@ impl Maid {
         let asym_keys = crypto::asymmetricbox::gen_keypair();
 
         Maid {
-            public_keys: (an_maid.get_public_key().clone(), asym_keys.0),
-            secret_keys: (an_maid.get_secret_key().clone(), asym_keys.1)
+            type_tag: 103u64,
+            public_keys: (an_maid.public_key().clone(), asym_keys.0),
+            secret_keys: (an_maid.secret_key().clone(), asym_keys.1)
         }
     }
     /// Returns the PublicKeys
-    pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey){
+    pub fn public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey){
         &self.public_keys
     }
     /// Signs the data with the SecretKey and returns the Signed data
@@ -79,15 +81,15 @@ impl Maid {
 impl cmp::PartialEq for Maid {
     fn eq(&self, other: &Maid) -> bool {
         // Private keys are mathematically linked, so just check public keys
-        let public0_equal =  slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0);
-        let public1_equal = slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0);
-        return public0_equal && public1_equal;
+        &self.type_tag == &other.type_tag &&
+        slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0) &&
+        slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0)
     }
 }
 
 impl fmt::Debug for Maid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Maid {{ public_keys: ({:?}, {:?}) }}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec())
+        write!(f, "Maid {{ type_tag:{}, public_keys: ({:?}, {:?}) }}", self.type_tag, self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec())
     }
 }
 
@@ -122,7 +124,7 @@ impl Decodable for Maid {
                         crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
         let sec_keys = (crypto::sign::SecretKey(sec_sign_arr.unwrap()),
                         crypto::asymmetricbox::SecretKey(sec_asym_arr.unwrap()));
-        Ok(Maid{ public_keys: pub_keys, secret_keys: sec_keys })
+        Ok(Maid{ type_tag: 103u64, public_keys: pub_keys, secret_keys: sec_keys })
     }
 }
 
@@ -153,8 +155,8 @@ mod test {
         let mut d = cbor::Decoder::from_bytes(e.as_bytes());
         let obj_after: Maid = d.decode().next().unwrap().unwrap();
 
-        let &(crypto::sign::PublicKey(pub_sign_arr_before), crypto::asymmetricbox::PublicKey(pub_asym_arr_before)) = obj_before.get_public_keys();
-        let &(crypto::sign::PublicKey(pub_sign_arr_after), crypto::asymmetricbox::PublicKey(pub_asym_arr_after)) = obj_after.get_public_keys();
+        let &(crypto::sign::PublicKey(pub_sign_arr_before), crypto::asymmetricbox::PublicKey(pub_asym_arr_before)) = obj_before.public_keys();
+        let &(crypto::sign::PublicKey(pub_sign_arr_after), crypto::asymmetricbox::PublicKey(pub_asym_arr_after)) = obj_after.public_keys();
         let &(crypto::sign::SecretKey(sec_sign_arr_before), crypto::asymmetricbox::SecretKey(sec_asym_arr_before)) = &obj_before.secret_keys;
         let &(crypto::sign::SecretKey(sec_sign_arr_after), crypto::asymmetricbox::SecretKey(sec_asym_arr_after)) = &obj_after.secret_keys;
 
@@ -180,24 +182,24 @@ mod test {
             let sign2 = maid2.sign(&random_bytes);
             assert!(sign1 != sign2);
 
-            assert!(crypto::sign::verify(&sign1, &maid1.get_public_keys().0).is_some());
-            assert!(crypto::sign::verify(&sign2, &maid1.get_public_keys().0).is_none());
+            assert!(crypto::sign::verify(&sign1, &maid1.public_keys().0).is_some());
+            assert!(crypto::sign::verify(&sign2, &maid1.public_keys().0).is_none());
 
-            assert!(crypto::sign::verify(&sign2, &maid2.get_public_keys().0).is_some());
-            assert!(crypto::sign::verify(&sign2, &maid1.get_public_keys().0).is_none());
+            assert!(crypto::sign::verify(&sign2, &maid2.public_keys().0).is_some());
+            assert!(crypto::sign::verify(&sign2, &maid1.public_keys().0).is_none());
         }
         {
             let maid3 = Maid::generate_random();
 
-            let encrypt1 = maid1.seal(&random_bytes, &maid3.get_public_keys().1);
-            let encrypt2 = maid2.seal(&random_bytes, &maid3.get_public_keys().1);
+            let encrypt1 = maid1.seal(&random_bytes, &maid3.public_keys().1);
+            let encrypt2 = maid2.seal(&random_bytes, &maid3.public_keys().1);
             assert!(encrypt1.0 != encrypt2.0);
 
-            assert!(maid3.open(&encrypt1.0, &encrypt1.1, &maid1.get_public_keys().1).is_ok());
-            assert!(maid3.open(&encrypt1.0, &encrypt1.1, &maid2.get_public_keys().1).is_err());
+            assert!(maid3.open(&encrypt1.0, &encrypt1.1, &maid1.public_keys().1).is_ok());
+            assert!(maid3.open(&encrypt1.0, &encrypt1.1, &maid2.public_keys().1).is_err());
 
-            assert!(maid3.open(&encrypt2.0, &encrypt2.1, &maid2.get_public_keys().1).is_ok());
-            assert!(maid3.open(&encrypt2.0, &encrypt2.1, &maid1.get_public_keys().1).is_err());
+            assert!(maid3.open(&encrypt2.0, &encrypt2.1, &maid2.public_keys().1).is_ok());
+            assert!(maid3.open(&encrypt2.0, &encrypt2.1, &maid1.public_keys().1).is_err());
         }
     }
 }

--- a/src/id/mpid.rs
+++ b/src/id/mpid.rs
@@ -46,8 +46,6 @@ use std::fmt;
 /// // getting Mpid::secret_keys
 /// let &(sec_sign, sec_asym) = mpid.get_public_keys();
 ///
-/// // getting Mpid::name
-/// let name: routing::NameType = mpid.get_name();
 /// ```
 #[derive(Clone)]
 pub struct Mpid {
@@ -74,7 +72,7 @@ impl fmt::Debug for Mpid {
 
 impl Sendable for Mpid {
     fn name(&self) -> NameType {
-        self.get_name()
+        name(&self.public_keys)
     }
 
     fn type_tag(&self)->u64 {
@@ -107,10 +105,6 @@ impl Mpid {
     /// Returns the SecretKeys
     pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
         &self.secret_keys
-    }
-    /// Returns the name
-    pub fn get_name(&self) -> NameType {
-        calculate_name(&self.public_keys)
     }
 }
 

--- a/src/id/mpid.rs
+++ b/src/id/mpid.rs
@@ -108,15 +108,9 @@ impl Mpid {
     pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
         &self.secret_keys
     }
-
     /// Returns the name
     pub fn get_name(&self) -> NameType {
-        let combined_iter = (self.public_keys.0).0.into_iter().chain((self.public_keys.1).0.into_iter()).collect::<Vec<_>>();
-        let mut combined: Vec<u8> = Vec::new();
-        for iter in combined_iter {
-            combined.push(*iter);
-        }
-        NameType(crypto::hash::sha512::hash(&combined).0)
+        calculate_name(&self.public_keys)
     }
 }
 

--- a/src/id/mpid.rs
+++ b/src/id/mpid.rs
@@ -42,13 +42,14 @@ use std::fmt;
 ///                     routing::NameType([6u8; 64]));
 ///
 /// // getting Mpid::public_keys
-/// let &(pub_sign, pub_asym) = mpid.get_public_keys();
+/// let &(pub_sign, pub_asym) = mpid.public_keys();
 ///
 /// // getting Mpid::secret_keys
-/// let &(sec_sign, sec_asym) = mpid.get_public_keys();
+/// let &(sec_sign, sec_asym) = mpid.public_keys();
 /// ```
 #[derive(Clone)]
 pub struct Mpid {
+    type_tag: u64,
     public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
     secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
     name: NameType
@@ -57,15 +58,16 @@ pub struct Mpid {
 impl PartialEq for Mpid {
     fn eq(&self, other: &Mpid) -> bool {
         // Private keys are mathematically linked, so just check public keys
-        let public0_equal = slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0);
-        let public1_equal = slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0);
-        return public0_equal && public1_equal && self.name == other.name;
+        &self.type_tag == &other.type_tag &&
+        slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0) &&
+        slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0) &&
+        self.name == other.name
     }
 }
 
 impl fmt::Debug for Mpid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Mpid {{ public_keys:({:?}, {:?}), secret_keys:({:?}, {:?}), name: {:?} }}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
+        write!(f, "Mpid {{ type_tag:{}, public_keys:({:?}, {:?}), secret_keys:({:?}, {:?}), name: {:?} }}", self.type_tag, self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
             self.secret_keys.0 .0.to_vec(), self.secret_keys.1 .0.to_vec(), self.name)
     }
 }
@@ -77,7 +79,7 @@ impl Sendable for Mpid {
     }
 
     fn type_tag(&self)->u64 {
-        104
+        self.type_tag.clone()
     }
 
     fn serialised_contents(&self)->Vec<u8> {
@@ -98,14 +100,14 @@ impl Mpid {
     pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
                          secret_keys: (crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey),
                          name_type: NameType) -> Mpid {
-        Mpid { public_keys: public_keys, secret_keys: secret_keys, name: name_type }
+        Mpid { type_tag: 104u64, public_keys: public_keys, secret_keys: secret_keys, name: name_type }
     }
     /// Returns the PublicKeys
-    pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey){
+    pub fn public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey){
         &self.public_keys
     }
     /// Returns the SecretKeys
-    pub fn get_secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
+    pub fn secret_keys(&self) -> &(crypto::sign::SecretKey, crypto::asymmetricbox::SecretKey) {
         &self.secret_keys
     }
 }
@@ -137,11 +139,11 @@ impl Decodable for Mpid {
             return Err(d.error("Bad Mpid size"));
         }
 
-        let pub_keys = (crypto::sign::PublicKey(pub_sign_arr.unwrap()),
-                crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap()));
-        let sec_keys = (crypto::sign::SecretKey(sec_sign_arr.unwrap()),
-                crypto::asymmetricbox::SecretKey(sec_asym_arr.unwrap()));
-        Ok(Mpid::new(pub_keys, sec_keys, name))
+
+
+        Ok(Mpid::new((crypto::sign::PublicKey(pub_sign_arr.unwrap()), crypto::asymmetricbox::PublicKey(pub_asym_arr.unwrap())),
+                     (crypto::sign::SecretKey(sec_sign_arr.unwrap()), crypto::asymmetricbox::SecretKey(sec_asym_arr.unwrap())),
+                     name))
     }
 }
 
@@ -158,6 +160,7 @@ mod test {
             let (sign_pub_key, sign_sec_key) = crypto::sign::gen_keypair();
             let (asym_pub_key, asym_sec_key) = crypto::asymmetricbox::gen_keypair();
             Mpid {
+                type_tag: 104u64,
                 public_keys: (sign_pub_key, asym_pub_key),
                 secret_keys: (sign_sec_key, asym_sec_key),
                 name: routing::test_utils::Random::generate_random()

--- a/src/id/public_an_maid.rs
+++ b/src/id/public_an_maid.rs
@@ -70,7 +70,7 @@ impl fmt::Debug for PublicAnMaid {
 
 impl Sendable for PublicAnMaid {
     fn name(&self) -> NameType {
-        self.get_name()
+        name(&self.public_keys)
     }
 
     fn type_tag(&self)->u64 {
@@ -84,7 +84,7 @@ impl Sendable for PublicAnMaid {
     }
 
     fn owner(&self) -> Option<NameType> {
-        Some(self.get_name())
+        Some(name(&self.public_keys))
     }
 
     fn refresh(&self)->bool {
@@ -108,11 +108,6 @@ impl PublicAnMaid {
         pub fn get_signature(&self) -> &crypto::sign::Signature {
             &self.signature
         }
-        /// Returns the name
-        pub fn get_name(&self) -> NameType {
-            calculate_name(&self.public_keys)
-        }
-
 }
 
 impl Encodable for PublicAnMaid {

--- a/src/id/public_an_maid.rs
+++ b/src/id/public_an_maid.rs
@@ -87,6 +87,10 @@ impl Sendable for PublicAnMaid {
         false
     }
 
+    fn owner(&self) -> Option<NameType> {
+        Some(self.get_name())
+    }
+
     fn merge(&self, _: Vec<Box<Sendable>>) -> Option<Box<Sendable>> { None }
 }
 

--- a/src/id/public_an_maid.rs
+++ b/src/id/public_an_maid.rs
@@ -94,27 +94,19 @@ impl PublicAnMaid {
         /// new() is invoked to create an instance of the PublicAnMaid
         pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
                                                  signature: crypto::sign::Signature) -> PublicAnMaid {
-                PublicAnMaid {
-                public_keys: public_keys,
-                signature: signature
-                }
+            PublicAnMaid {public_keys: public_keys, signature: signature }
         }
         /// Returns the PublicKeys
         pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
-                &self.public_keys
+            &self.public_keys
         }
         /// Returns the Signature
         pub fn get_signature(&self) -> &crypto::sign::Signature {
-                &self.signature
+            &self.signature
         }
         /// Returns the name
         pub fn get_name(&self) -> NameType {
-            let combined_iter = (self.public_keys.0).0.into_iter().chain((self.public_keys.1).0.into_iter()).collect::<Vec<_>>();
-            let mut combined: Vec<u8> = Vec::new();
-            for iter in combined_iter {
-                combined.push(*iter);
-            }
-            NameType(crypto::hash::sha512::hash(&combined).0)
+            calculate_name(&self.public_keys)
         }
 
 }

--- a/src/id/public_an_maid.rs
+++ b/src/id/public_an_maid.rs
@@ -83,12 +83,12 @@ impl Sendable for PublicAnMaid {
         e.into_bytes()
     }
 
-    fn refresh(&self)->bool {
-        false
-    }
-
     fn owner(&self) -> Option<NameType> {
         Some(self.get_name())
+    }
+
+    fn refresh(&self)->bool {
+        false
     }
 
     fn merge(&self, _: Vec<Box<Sendable>>) -> Option<Box<Sendable>> { None }

--- a/src/id/public_maid.rs
+++ b/src/id/public_maid.rs
@@ -137,14 +137,8 @@ impl PublicMaid {
     }
     /// Returns the name
     pub fn get_name(&self) -> NameType {
-        let combined_iter = (self.public_keys.0).0.into_iter().chain((self.public_keys.1).0.into_iter()).collect::<Vec<_>>();
-        let mut combined: Vec<u8> = Vec::new();
-        for iter in combined_iter {
-            combined.push(*iter);
-        }
-        NameType(crypto::hash::sha512::hash(&combined).0)
+        calculate_name(&self.public_keys)
     }
-
 }
 
 impl Encodable for PublicMaid {

--- a/src/id/public_maid.rs
+++ b/src/id/public_maid.rs
@@ -55,8 +55,6 @@ use std::fmt;
 /// // getting PublicMaid::signature
 /// let signature: &sodiumoxide::crypto::sign::Signature = public_maid.get_signature();
 ///
-/// // getting PublicMaid::name
-/// let name: routing::NameType = public_maid.get_name();
 /// ```
 
 #[derive(Clone)]
@@ -69,7 +67,7 @@ pub struct PublicMaid {
 
 impl Sendable for PublicMaid {
     fn name(&self) -> NameType {
-        self.get_name()
+        name(&self.public_keys)
     }
 
     fn type_tag(&self)->u64 {
@@ -134,10 +132,6 @@ impl PublicMaid {
     /// Returns the Signature of PublicMaid
     pub fn get_signature(&self) -> &crypto::sign::Signature {
         &self.signature
-    }
-    /// Returns the name
-    pub fn get_name(&self) -> NameType {
-        calculate_name(&self.public_keys)
     }
 }
 

--- a/src/id/public_maid.rs
+++ b/src/id/public_maid.rs
@@ -44,21 +44,22 @@ use std::fmt;
 ///                     sodiumoxide::crypto::sign::Signature([5u8; 64]));
 ///
 /// // getting PublicMaid::public_keys
-/// let &(pub_sign, pub_asym) = public_maid.get_public_keys();
+/// let &(pub_sign, pub_asym) = public_maid.public_keys();
 ///
 /// // getting PublicMaid::mpid_signature
-/// let maid_signature: &sodiumoxide::crypto::sign::Signature = public_maid.get_maid_signature();
+/// let maid_signature: &sodiumoxide::crypto::sign::Signature = public_maid.maid_signature();
 ///
 /// // getting PublicMaid::owner
-/// let owner: &routing::NameType = public_maid.get_owner();
+/// let owner: &routing::NameType = public_maid.owner();
 ///
 /// // getting PublicMaid::signature
-/// let signature: &sodiumoxide::crypto::sign::Signature = public_maid.get_signature();
+/// let signature: &sodiumoxide::crypto::sign::Signature = public_maid.signature();
 ///
 /// ```
 
 #[derive(Clone)]
 pub struct PublicMaid {
+    type_tag: u64,
     public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
     maid_signature: crypto::sign::Signature,
     owner: NameType,
@@ -71,7 +72,7 @@ impl Sendable for PublicMaid {
     }
 
     fn type_tag(&self)->u64 {
-        106
+        self.type_tag.clone()
     }
 
     fn serialised_contents(&self)->Vec<u8> {
@@ -93,17 +94,17 @@ impl Sendable for PublicMaid {
 
 impl PartialEq for PublicMaid {
     fn eq(&self, other: &PublicMaid) -> bool {
-        let pub1_equal = slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0);
-        let pub2_equal = slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0);
-        let sig1_equal = slice_equal(&self.maid_signature.0, &other.maid_signature.0);
-        let sig2_equal = slice_equal(&self.signature.0, &other.signature.0);
-        return pub1_equal && pub2_equal && sig1_equal && sig2_equal;
+        &self.type_tag == &other.type_tag &&
+        slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0) &&
+        slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0) &&
+        slice_equal(&self.maid_signature.0, &other.maid_signature.0) &&
+        slice_equal(&self.signature.0, &other.signature.0)
     }
 }
 
 impl fmt::Debug for PublicMaid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "PublicMaid {{ public_keys:({:?}, {:?}), maid_signature:{:?}, owner:{:?}, signature:{:?}}}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
+        write!(f, "PublicMaid {{ type_tag:{}, public_keys:({:?}, {:?}), maid_signature:{:?}, owner:{:?}, signature:{:?}}}", self.type_tag, self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
             self.maid_signature.0.to_vec(), self.owner, self.signature.0.to_vec())
     }
 }
@@ -114,23 +115,23 @@ impl PublicMaid {
                          maid_signature: crypto::sign::Signature,
                          owner: NameType,
                          signature: crypto::sign::Signature) -> PublicMaid {
-        PublicMaid {public_keys: public_keys, maid_signature: maid_signature, owner: owner,
-                    signature: signature}
+        PublicMaid {type_tag: 107u64, public_keys: public_keys, maid_signature: maid_signature,
+             owner: owner, signature: signature}
     }
     /// Returns the PublicKeys
-    pub fn get_public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
+    pub fn public_keys(&self) -> &(crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey) {
         &self.public_keys
     }
     /// Returns the Maid Signature
-    pub fn get_maid_signature(&self) -> &crypto::sign::Signature {
+    pub fn maid_signature(&self) -> &crypto::sign::Signature {
         &self.maid_signature
     }
     /// Returns the Owner
-    pub fn get_owner(&self) -> &NameType {
+    pub fn owner(&self) -> &NameType {
         &self.owner
     }
     /// Returns the Signature of PublicMaid
-    pub fn get_signature(&self) -> &crypto::sign::Signature {
+    pub fn signature(&self) -> &crypto::sign::Signature {
         &self.signature
     }
 }
@@ -194,6 +195,7 @@ mod test {
             }
 
             PublicMaid {
+                type_tag: 107u64,
                 public_keys: (sign_pub_key, asym_pub_key),
                 maid_signature: crypto::sign::Signature(maid_signature_arr),
                 owner: routing::test_utils::Random::generate_random(),

--- a/src/id/public_mpid.rs
+++ b/src/id/public_mpid.rs
@@ -55,8 +55,6 @@ use std::fmt;
 /// // getting PublicMpid::signature
 /// let signature: &sodiumoxide::crypto::sign::Signature = public_mpid.get_signature();
 ///
-/// // getting PublicMpid::name
-/// let name: routing::NameType = public_mpid.get_name();
 /// ```
 
 #[derive(Clone)]
@@ -69,7 +67,7 @@ signature: crypto::sign::Signature
 
 impl Sendable for PublicMpid {
     fn name(&self) -> NameType {
-        self.get_name()
+        name(&self.public_keys)
     }
 
     fn type_tag(&self)->u64 {
@@ -156,11 +154,6 @@ impl PublicMpid {
     #[warn(dead_code)]
     pub fn get_signature(& self) -> &crypto::sign::Signature {
         &self.signature
-    }
-
-    /// Returns the name
-    pub fn get_name(&self) -> NameType {
-        calculate_name(&self.public_keys)
     }
 }
 

--- a/src/id/public_mpid.rs
+++ b/src/id/public_mpid.rs
@@ -160,12 +160,7 @@ impl PublicMpid {
 
     /// Returns the name
     pub fn get_name(&self) -> NameType {
-        let combined_iter = (self.public_keys.0).0.into_iter().chain((self.public_keys.1).0.into_iter()).collect::<Vec<_>>();
-        let mut combined: Vec<u8> = Vec::new();
-        for iter in combined_iter {
-            combined.push(*iter);
-        }
-        NameType(crypto::hash::sha512::hash(&combined).0)
+        calculate_name(&self.public_keys)
     }
 }
 

--- a/src/id/public_mpid.rs
+++ b/src/id/public_mpid.rs
@@ -13,7 +13,7 @@
 // KIND, either express or implied.
 //
 // Please review the Licences for the specific language governing permissions and limitations
-// relating to use of the SAFE Network Software. 
+// relating to use of the SAFE Network Software.
 
 use cbor;
 use cbor::CborTagEncode;
@@ -41,8 +41,7 @@ use std::fmt;
 /// let public_mpid  = maidsafe_types::PublicMpid::new((pub_sign_key, pub_asym_key),
 ///                     sodiumoxide::crypto::sign::Signature([2u8; 64]),
 ///                     routing::NameType([8u8; 64]),
-///                     sodiumoxide::crypto::sign::Signature([5u8; 64]),
-///                    routing::NameType([6u8; 64]));
+///                     sodiumoxide::crypto::sign::Signature([5u8; 64]));
 ///
 /// // getting PublicMpid::public_keys
 /// let &(pub_sign, pub_asym) = public_mpid.get_public_keys();
@@ -57,34 +56,20 @@ use std::fmt;
 /// let signature: &sodiumoxide::crypto::sign::Signature = public_mpid.get_signature();
 ///
 /// // getting PublicMpid::name
-/// let name: &routing::NameType = public_mpid.get_name();
+/// let name: routing::NameType = public_mpid.get_name();
 /// ```
+
 #[derive(Clone)]
 pub struct PublicMpid {
 public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
 mpid_signature: crypto::sign::Signature,
 owner: NameType,
-signature: crypto::sign::Signature,
-name: NameType
+signature: crypto::sign::Signature
 }
 
 impl Sendable for PublicMpid {
     fn name(&self) -> NameType {
-        let sign_arr = &(&self.public_keys.0).0;
-        let asym_arr = &(&self.public_keys.1).0;
-
-        let mut arr_combined = [0u8; 64 * 2];
-
-        for i in 0..sign_arr.len() {
-            arr_combined[i] = sign_arr[i];
-        }
-        for i in 0..asym_arr.len() {
-            arr_combined[64 + i] = asym_arr[i];
-        }
-
-        let digest = crypto::hash::sha512::hash(&arr_combined);
-
-        NameType(digest.0)
+        self.get_name()
     }
 
     fn type_tag(&self)->u64 {
@@ -94,14 +79,14 @@ impl Sendable for PublicMpid {
     fn serialised_contents(&self)->Vec<u8> {
         let mut e = cbor::Encoder::from_memory();
         e.encode(&[&self]).unwrap();
-        e.into_bytes()      
+        e.into_bytes()
     }
 
 
     fn owner(&self) -> Option<NameType> {
         Some(self.owner.clone())
     }
-    
+
     fn refresh(&self)->bool {
         false
     }
@@ -115,14 +100,14 @@ impl PartialEq for PublicMpid {
         let pub2_equal = slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0);
         let sig1_equal = slice_equal(&self.mpid_signature.0, &other.mpid_signature.0);
         let sig2_equal = slice_equal(&self.signature.0, &other.signature.0);
-        return pub1_equal && pub2_equal && sig1_equal && sig2_equal && self.name == other.name;
+        return pub1_equal && pub2_equal && sig1_equal && sig2_equal;
     }
 }
 
 impl fmt::Debug for PublicMpid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "PublicMpid {{ public_keys:({:?}, {:?}), mpid_signature:{:?}, owner:{:?}, signature:{:?}, name: {:?} }}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
-            self.mpid_signature.0.to_vec(), self.owner, self.signature.0.to_vec(), self.name)
+        write!(f, "PublicMpid {{ public_keys:({:?}, {:?}), mpid_signature:{:?}, owner:{:?}, signature:{:?}}}", self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(),
+            self.mpid_signature.0.to_vec(), self.owner, self.signature.0.to_vec())
     }
 }
 
@@ -135,20 +120,17 @@ impl PublicMpid {
     /// let public_mpid  = maidsafe_types::PublicMpid::new((pub_sign_key, pub_asym_key),
     ///                     sodiumoxide::crypto::sign::Signature([2u8; 64]),
     ///                     routing::NameType([8u8; 64]),
-    ///                     sodiumoxide::crypto::sign::Signature([5u8; 64]),
-    ///                    routing::NameType([6u8; 64]));
+    ///                     sodiumoxide::crypto::sign::Signature([5u8; 64]));
     ///
     pub fn new(public_keys: (crypto::sign::PublicKey, crypto::asymmetricbox::PublicKey),
                          mpid_signature: crypto::sign::Signature,
                          owner: NameType,
-                         signature: crypto::sign::Signature,
-                         name: NameType) -> PublicMpid {
+                         signature: crypto::sign::Signature) -> PublicMpid {
         PublicMpid {
         public_keys: public_keys,
         mpid_signature: mpid_signature,
         owner: owner,
-        signature: signature,
-        name: name,
+        signature: signature
         }
     }
 
@@ -176,10 +158,14 @@ impl PublicMpid {
         &self.signature
     }
 
-    /// Returns the name for the PublicMpid
-    #[warn(dead_code)]
-    pub fn get_name(& self) -> &NameType {
-        &self.name
+    /// Returns the name
+    pub fn get_name(&self) -> NameType {
+        let combined_iter = (self.public_keys.0).0.into_iter().chain((self.public_keys.1).0.into_iter()).collect::<Vec<_>>();
+        let mut combined: Vec<u8> = Vec::new();
+        for iter in combined_iter {
+            combined.push(*iter);
+        }
+        NameType(crypto::hash::sha512::hash(&combined).0)
     }
 }
 
@@ -193,8 +179,7 @@ impl Encodable for PublicMpid {
                         pub_asym_vec.as_ref(),
                 mpid_signature.as_ref(),
                 &self.owner,
-                    signature.as_ref(),
-                &self.name)).encode(e)
+                signature.as_ref())).encode(e)
     }
 }
 
@@ -202,7 +187,7 @@ impl Decodable for PublicMpid {
     fn decode<D: Decoder>(d: &mut D)-> Result<PublicMpid, D::Error> {
     try!(d.read_u64());
 
-    let (pub_sign_vec, pub_asym_vec, mpid_signature_vec, owner, signature_vec, name) : (Vec<u8>, Vec<u8>, Vec<u8>, NameType, Vec<u8>, NameType) = try!(Decodable::decode(d));
+    let (pub_sign_vec, pub_asym_vec, mpid_signature_vec, owner, signature_vec) : (Vec<u8>, Vec<u8>, Vec<u8>, NameType, Vec<u8>) = try!(Decodable::decode(d));
         let pub_sign_arr = convert_to_array!(pub_sign_vec, crypto::sign::PUBLICKEYBYTES);
         let pub_asym_arr = convert_to_array!(pub_asym_vec, crypto::asymmetricbox::PUBLICKEYBYTES);
         let mpid_signature_arr = convert_to_array!(mpid_signature_vec, crypto::sign::SIGNATUREBYTES);
@@ -217,7 +202,7 @@ impl Decodable for PublicMpid {
     let parsed_mpid_signature = crypto::sign::Signature(mpid_signature_arr.unwrap());
     let parsed_signature = crypto::sign::Signature(signature_arr.unwrap());
 
-    Ok(PublicMpid::new(pub_keys, parsed_mpid_signature, owner, parsed_signature, name))
+    Ok(PublicMpid::new(pub_keys, parsed_mpid_signature, owner, parsed_signature))
     }
 }
 
@@ -246,8 +231,7 @@ mod test {
                 public_keys: (sign_pub_key, asym_pub_key),
                 mpid_signature: crypto::sign::Signature(mpid_signature_arr),
                 owner: routing::test_utils::Random::generate_random(),
-                signature: crypto::sign::Signature(signature_arr),
-                name: routing::test_utils::Random::generate_random()
+                signature: crypto::sign::Signature(signature_arr)
             }
         }
     }
@@ -274,5 +258,5 @@ mod test {
         assert_eq!(public_mpid_first, public_mpid_second);
         assert!(public_mpid_first != public_mpid_third);
     }
-    
+
 }


### PR DESCRIPTION
1- Removes name as a member variable from types.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_types/47)

<!-- Reviewable:end -->
